### PR TITLE
feat(cli): migrate CLI to Click and add shell completion

### DIFF
--- a/cardonnay/main.py
+++ b/cardonnay/main.py
@@ -1,0 +1,92 @@
+"""Cardonnay CLI entry point."""
+
+import logging
+import typing as tp
+
+import click
+
+from cardonnay import cli
+
+LOGGER = logging.getLogger(__name__)
+
+
+def common_options(func: tp.Callable) -> tp.Callable:
+    """Add shared options using a decorator."""
+    func = click.option(
+        "-w", "--work-dir", default="", help="Path to working directory.", type=str
+    )(func)
+    func = click.option(
+        "-i",
+        "--instance-num",
+        default=0,
+        help="Instance number in the sequence of cluster instances (default: 0).",
+        type=int,
+    )(func)
+    return func
+
+
+@click.group()
+def main() -> None:
+    """Cardonnay - Cardano local testnets."""
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+
+@main.command(help="Generate local testnet configuration")
+@click.option("-t", "--testnet-variant", help="Testnet variant to use.", type=str)
+@click.option("-l", "--list", is_flag=True, help="List available testnet variants and exit.")
+@click.option("-r", "--run", is_flag=True, help="Run the testnet immediately (default: false).")
+@click.option("-c", "--clean", is_flag=True, help="Delete destination directory if it exists.")
+@click.option(
+    "-s",
+    "--stake-pools-num",
+    type=int,
+    default=3,
+    help="Number of stake pools to create (default: 3).",
+)
+@click.option(
+    "-p",
+    "--ports-base",
+    type=int,
+    default=23000,
+    help="Base port number (default: 23000).",
+)
+@common_options
+def generate(
+    testnet_variant: str,
+    list: bool,
+    run: bool,
+    clean: bool,
+    stake_pools_num: int,
+    ports_base: int,
+    work_dir: str,
+    instance_num: int,
+) -> None:
+    retval = cli.cmd_generate(
+        testnet_variant,
+        list,
+        run,
+        clean,
+        stake_pools_num,
+        ports_base,
+        work_dir,
+        instance_num,
+    )
+    raise SystemExit(retval)
+
+
+@main.command(help="Control existing testnets.")
+@click.option("-l", "--list", is_flag=True, help="List running testnet instances.")
+@click.option("-s", "--stop", is_flag=True, help="Stop the running testnet.")
+@click.option("-r", "--restart", is_flag=True, help="Restart all processes of the testnet.")
+@click.option("-n", "--restart-nodes", is_flag=True, help="Restart only nodes of the testnet.")
+@common_options
+def control(
+    list: bool,
+    stop: bool,
+    restart: bool,
+    restart_nodes: bool,
+    work_dir: str,
+    instance_num: int,
+) -> None:
+    retval = cli.cmd_control(list, stop, restart, restart_nodes, work_dir, instance_num)
+    raise SystemExit(retval)

--- a/flake.nix
+++ b/flake.nix
@@ -39,13 +39,14 @@
                 py3Pkgs.pip
               ];
               shellHook = ''
-                echo "Setting up Python environment..."
+                echo "Setting up environment..."
                 rm -rf .venv_nix
                 python3 -m venv .venv_nix
                 source .venv_nix/bin/activate
                 export PYTHONPATH=$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):"$PYTHONPATH"
                 make install
-                echo "Python environment ready."
+                eval "$(_CARDONNAY_COMPLETE=bash_source cardonnay)"
+                echo "Environment ready."
               '';
             };
             # Use 'venv' directly as 'default'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = ["version"]
 dependencies = [
     "setuptools < 80.9",
     "supervisor",
+    "click",
 ]
 
 [project.urls]
@@ -34,7 +35,7 @@ documentation = "https://github.com/IntersectMBO/cardonnay"
 repository = "https://github.com/IntersectMBO/cardonnay"
 
 [project.scripts]
-cardonnay = "cardonnay.cli:main"
+cardonnay = "cardonnay.main:main"
 
 [tool.setuptools.packages.find]
 where = ["cardonnay_scripts", "cardonnay"]


### PR DESCRIPTION
Refactor the CLI to use the Click library for command-line parsing, replacing argparse. This enables improved help output, easier option management, and built-in shell completion support. The CLI entry point is now in `cardonnay.main:main`. Also update dependencies and flake.nix to support the new CLI and enable shell completion in the dev shell.