### PR TITLE
fix(config): correct testnet name in conway_slow config

### DIFF
--- a/src/cardonnay_scripts/scripts/conway_slow/testnet.json
+++ b/src/cardonnay_scripts/scripts/conway_slow/testnet.json
@@ -1,5 +1,5 @@
 {
-    "name": "conway_fast",
+    "name": "conway_slow",
     "description": "Local testnet that starts in Byron era and hard-forks through all the protocol versions until it gets to Conway.",
     "control_env": {
         "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",


### PR DESCRIPTION
Updated the "name" field in the conway_slow testnet configuration file from "conway_fast" to "conway_slow" to accurately reflect the intended testnet setup. This ensures consistency between the file name and its internal configuration.