### PR TITLE
fix(dev-env): only create venv if missing in shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,7 @@
               ];
               shellHook = ''
                 echo "Setting up environment..."
-                rm -rf .venv_nix
-                python3 -m venv .venv_nix
+                [ -e .venv_nix ] || python3 -m venv .venv_nix
                 source .venv_nix/bin/activate
                 export PYTHONPATH=$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):"$PYTHONPATH"
                 make install


### PR DESCRIPTION
Previously, the shellHook always removed and recreated the .venv_nix virtual environment, which could be slow and unnecessary. Now, it only creates the venv if it does not already exist, improving efficiency and preserving installed packages between shell sessions.