### PR TITLE
feat: add comment support to testnet generation

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -82,13 +82,17 @@ def print_instances(workdir: pl.Path) -> None:
     for i in running_instances:
         statedir = workdir / f"state-cluster{i}"
         try:
-            with open(statedir / "testnet.json", encoding="utf-8") as fp_in:
-                testnet_info = json.load(fp_in)
+            with open(statedir / cli_utils.TESTNET_JSON, encoding="utf-8") as fp_in:
+                testnet_info = json.load(fp_in) or {}
         except Exception:
             testnet_info = {}
         testnet_name = testnet_info.get("name") or "unknown"
         testnet_status = "started" if (statedir / STATUS_STARTED).exists() else "starting"
-        out_list.append({"instance": i, "type": testnet_name, "status": testnet_status})
+        instance_info = {"instance": i, "type": testnet_name, "status": testnet_status}
+        testnet_comment = testnet_info.get("comment")
+        if testnet_comment:
+            instance_info["comment"] = testnet_comment
+        out_list.append(instance_info)
     print(json.dumps(out_list, indent=2))
 
 

--- a/src/cardonnay/cli_generate.py
+++ b/src/cardonnay/cli_generate.py
@@ -37,8 +37,8 @@ def print_available_testnets(scripts_base: pl.Path, verbose: bool) -> int:
         out_list = []
         for d in avail_scripts:
             try:
-                with open(scripts_base / d / "testnet.json", encoding="utf-8") as fp_in:
-                    testnet_info = json.load(fp_in)
+                with open(scripts_base / d / cli_utils.TESTNET_JSON, encoding="utf-8") as fp_in:
+                    testnet_info = json.load(fp_in) or {}
             except Exception:
                 testnet_info = {"name": d}
             out_list.append(testnet_info)
@@ -70,8 +70,21 @@ def testnet_start(testnetdir: pl.Path, workdir: pl.Path, env: dict) -> int:
     return 0
 
 
+def add_comment(destdir: pl.Path, comment: str) -> None:
+    testnet_file = destdir / cli_utils.TESTNET_JSON
+    try:
+        with open(testnet_file, encoding="utf-8") as fp_in:
+            testnet_info: dict = json.load(fp_in) or {}
+    except Exception:
+        testnet_info = {}
+
+    testnet_info["comment"] = comment
+    helpers.write_json(out_file=testnet_file, content=testnet_info)
+
+
 def cmd_generate(  # noqa: PLR0911, C901
     testnet_variant: str,
+    comment: str,
     listit: bool,
     run: bool,
     keep: bool,
@@ -133,6 +146,9 @@ def cmd_generate(  # noqa: PLR0911, C901
     except Exception:
         LOGGER.exception("Failure")
         return 1
+
+    if comment:
+        add_comment(destdir=destdir_abs, comment=comment)
 
     env = cli_utils.create_env_vars(workdir=workdir_abs, instance_num=instance_num)
     write_env_vars(env=env, workdir=workdir_abs, instance_num=instance_num)

--- a/src/cardonnay/cli_utils.py
+++ b/src/cardonnay/cli_utils.py
@@ -9,6 +9,7 @@ from cardonnay import ttypes
 LOGGER = logging.getLogger(__name__)
 
 MAX_INSTANCES = 10
+TESTNET_JSON = "testnet.json"
 
 
 def create_env_vars(workdir: pl.Path, instance_num: int) -> dict[str, str]:

--- a/src/cardonnay/main.py
+++ b/src/cardonnay/main.py
@@ -52,6 +52,18 @@ def exit_with(retval: int) -> tp.NoReturn:
     click.get_current_context().exit(retval)
 
 
+def validate_comment(
+    ctx: click.Context,  # noqa: ARG001
+    param: click.Parameter,  # noqa: ARG001
+    value: str,
+) -> str:
+    max_char = 255
+    if value is not None and len(value) > max_char:
+        err = f"must be {max_char} characters or fewer."
+        raise click.BadParameter(err)
+    return value
+
+
 @click.group()
 def main() -> None:
     """Cardonnay - Cardano local testnets."""
@@ -60,6 +72,9 @@ def main() -> None:
 
 @main.command(help="Generate local testnet configuration")
 @click.option("-t", "--testnet-variant", type=str, help="Testnet variant to use.")
+@click.option(
+    "-c", "--comment", type=str, callback=validate_comment, help="Comment for the testnet."
+)
 @click.option("-l", "--ls", is_flag=True, help="List available testnet variants and exit.")
 @click.option("-r", "--run", is_flag=True, help="Run the testnet immediately (default: false).")
 @click.option("-k", "--keep", is_flag=True, help="Don't delete destination directory if it exists.")
@@ -88,6 +103,7 @@ def main() -> None:
 def generate(
     ctx: click.Context,
     testnet_variant: str,
+    comment: str,
     ls: bool,
     run: bool,
     keep: bool,
@@ -104,6 +120,7 @@ def generate(
 
     retval = cli_generate.cmd_generate(
         testnet_variant=testnet_variant,
+        comment=comment,
         listit=ls,
         run=run,
         keep=keep,


### PR DESCRIPTION
This commit introduces the ability to add a comment to a testnet during generation via the `--comment` CLI option. The comment is stored in `testnet.json` and displayed when listing instances. Input is validated to ensure comments do not exceed 255 characters. This enhances documentation and traceability of testnet instances.