### PR TITLE
fix(cli): exit with code 1 when no args are provided

### DIFF
--- a/src/cardonnay/main.py
+++ b/src/cardonnay/main.py
@@ -116,7 +116,7 @@ def generate(
     # Check if no args were passed other than the command itself
     if not ctx.args and not any([testnet_variant, ls]):
         click.echo(ctx.get_help())
-        ctx.exit()
+        ctx.exit(1)
 
     retval = cli_generate.cmd_generate(
         testnet_variant=testnet_variant,


### PR DESCRIPTION
Previously, the CLI exited with code 0 when no arguments were passed, which could be misleading in automation or scripting contexts. Now, it exits with code 1 to indicate improper usage, aligning with standard CLI conventions.