### PR TITLE
refactor(cli): use JSON output for listing commands

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -79,7 +79,6 @@ def print_instances(workdir: pl.Path) -> None:
     """Print the list of running testnet instances."""
     running_instances = sorted(cli_utils.get_running_instances(workdir=workdir))
 
-    print("Running instances:")
     out_list = []
     for i in running_instances:
         statedir = workdir / f"state-cluster{i}"

--- a/src/cardonnay/cli_generate.py
+++ b/src/cardonnay/cli_generate.py
@@ -33,7 +33,6 @@ def print_available_testnets(scripts_base: pl.Path, verbose: bool) -> int:
         LOGGER.error(f"No script directories found in '{scripts_base}'.")
         return 1
 
-    print("Available testnet variants:")
     if verbose:
         out_list = []
         for d in avail_scripts:
@@ -45,8 +44,7 @@ def print_available_testnets(scripts_base: pl.Path, verbose: bool) -> int:
             out_list.append(testnet_info)
         helpers.print_json(data=out_list)
     else:
-        for d in avail_scripts:
-            print(f"  - {d}")
+        helpers.print_json(data=avail_scripts)
     return 0
 
 


### PR DESCRIPTION
Replace plain text print statements with JSON output in both `print_instances` and `print_available_testnets` functions. This change improves consistency and makes the output easier to parse programmatically.