### PR TITLE
fix(cli): clarify log messages for testnet cluster actions

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -24,11 +24,11 @@ def testnet_stop(statedir: pl.Path, env: dict) -> int:
 
     cli_utils.set_env_vars(env=env)
 
-    LOGGER.info(f"Stopping testnet with `{stop_script}`.")
+    LOGGER.info(f"Stopping the testnet cluster with `{stop_script}`.")
     try:
         helpers.run_command(str(stop_script), workdir=statedir)
     except RuntimeError:
-        LOGGER.exception("Failed to stop testnet")
+        LOGGER.exception("Failed to stop the testnet cluster")
         return 1
 
     return 0

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -90,11 +90,11 @@ def testnet_start(
         }
         helpers.print_json(instance_info)
     else:
-        LOGGER.info(f"Starting cluster with `{start_script}`.")
+        LOGGER.info(f"Starting the testnet cluster with `{start_script}`.")
         try:
             helpers.run_command(command=str(start_script), workdir=workdir)
         except RuntimeError:
-            LOGGER.exception("Failed to start testnet")
+            LOGGER.exception("Failed to start the testnet cluster")
             return 1
 
     return 0
@@ -189,7 +189,7 @@ def cmd_create(  # noqa: PLR0911, C901
     LOGGER.debug(f"Testnet files generated to {destdir}")
 
     if generate_only:
-        LOGGER.info("You can start the testnet with:")
+        LOGGER.info("You can start the testnet cluster with:")
         LOGGER.info(f"source {workdir}/.source_cluster{instance_num}")
         LOGGER.info(f"{destdir}/start-cluster")
     else:


### PR DESCRIPTION
Update log messages in cli_control.py and cli_create.py to consistently refer to the "testnet cluster" when starting or stopping, improving clarity for users. Also update instructions to use "testnet cluster" for consistency.