### PR TITLE
refactor(cli): replace LOGGER.info with print for user messages

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -24,7 +24,7 @@ def testnet_stop(statedir: pl.Path, env: dict) -> int:
 
     cli_utils.set_env_vars(env=env)
 
-    LOGGER.info(f"Stopping the testnet cluster with `{stop_script}`.")
+    print(f"Stopping the testnet cluster with `{stop_script}`:")
     try:
         helpers.run_command(str(stop_script), workdir=statedir)
     except RuntimeError:
@@ -59,7 +59,7 @@ def testnet_restart_nodes(statedir: pl.Path, env: dict) -> int:
 
     cli_utils.set_env_vars(env=env)
 
-    LOGGER.info(f"Restarting testnet nodes with `{script}`.")
+    print(f"Restarting testnet nodes with `{script}`:")
     try:
         helpers.run_command(str(script), workdir=statedir)
     except RuntimeError:
@@ -82,7 +82,7 @@ def testnet_restart_all(statedir: pl.Path, env: dict) -> int:
     cli_utils.set_env_vars(env=env)
 
     cmd = f"{script} restart all"
-    LOGGER.info(f"Restarting testnet with `{cmd}`.")
+    print(f"Restarting testnet with `{cmd}`:")
     try:
         helpers.run_command(cmd, workdir=statedir)
     except RuntimeError:

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -90,7 +90,7 @@ def testnet_start(
         }
         helpers.print_json(instance_info)
     else:
-        LOGGER.info(f"Starting the testnet cluster with `{start_script}`.")
+        print(f"Starting the testnet cluster with `{start_script}`:")
         try:
             helpers.run_command(command=str(start_script), workdir=workdir)
         except RuntimeError:
@@ -189,9 +189,9 @@ def cmd_create(  # noqa: PLR0911, C901
     LOGGER.debug(f"Testnet files generated to {destdir}")
 
     if generate_only:
-        LOGGER.info("You can start the testnet cluster with:")
-        LOGGER.info(f"source {workdir}/.source_cluster{instance_num}")
-        LOGGER.info(f"{destdir}/start-cluster")
+        print("🚀 You can now start the testnet cluster with:")
+        print(f"source {workdir}/.source_cluster{instance_num}")
+        print(f"{destdir}/start-cluster")
     else:
         run_retval = testnet_start(
             testnetdir=destdir_abs,


### PR DESCRIPTION
Replaces LOGGER.info calls with print statements in CLI commands to provide clearer user-facing output during testnet operations.