### PR TITLE
feat(cli): add colorized output and logging

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -7,6 +7,7 @@ import signal
 import time
 
 from cardonnay import cli_utils
+from cardonnay import colors
 from cardonnay import helpers
 
 LOGGER = logging.getLogger(__name__)
@@ -24,7 +25,10 @@ def testnet_stop(statedir: pl.Path, env: dict) -> int:
 
     cli_utils.set_env_vars(env=env)
 
-    print(f"Stopping the testnet cluster with `{stop_script}`:")
+    print(
+        f"{colors.BColors.OKGREEN}Stopping the testnet cluster with "
+        f"`{stop_script}`:{colors.BColors.ENDC}"
+    )
     try:
         helpers.run_command(str(stop_script), workdir=statedir)
     except RuntimeError:
@@ -59,7 +63,7 @@ def testnet_restart_nodes(statedir: pl.Path, env: dict) -> int:
 
     cli_utils.set_env_vars(env=env)
 
-    print(f"Restarting testnet nodes with `{script}`:")
+    print(f"{colors.BColors.OKGREEN}Restarting testnet nodes with `{script}`:{colors.BColors.ENDC}")
     try:
         helpers.run_command(str(script), workdir=statedir)
     except RuntimeError:
@@ -82,7 +86,7 @@ def testnet_restart_all(statedir: pl.Path, env: dict) -> int:
     cli_utils.set_env_vars(env=env)
 
     cmd = f"{script} restart all"
-    print(f"Restarting testnet with `{cmd}`:")
+    print(f"{colors.BColors.OKGREEN}Restarting testnet with `{cmd}`:{colors.BColors.ENDC}")
     try:
         helpers.run_command(cmd, workdir=statedir)
     except RuntimeError:

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -5,6 +5,7 @@ import shutil
 
 import cardonnay_scripts
 from cardonnay import cli_utils
+from cardonnay import colors
 from cardonnay import helpers
 from cardonnay import local_scripts
 
@@ -90,7 +91,10 @@ def testnet_start(
         }
         helpers.print_json(instance_info)
     else:
-        print(f"Starting the testnet cluster with `{start_script}`:")
+        print(
+            f"{colors.BColors.OKGREEN}Starting the testnet cluster with "
+            f"`{start_script}`:{colors.BColors.ENDC}"
+        )
         try:
             helpers.run_command(command=str(start_script), workdir=workdir)
         except RuntimeError:
@@ -189,7 +193,10 @@ def cmd_create(  # noqa: PLR0911, C901
     LOGGER.debug(f"Testnet files generated to {destdir}")
 
     if generate_only:
-        print("🚀 You can now start the testnet cluster with:")
+        print(
+            f"🚀 {colors.BColors.OKGREEN}You can now start the testnet cluster "
+            f"with:{colors.BColors.ENDC}"
+        )
         print(f"source {workdir}/.source_cluster{instance_num}")
         print(f"{destdir}/start-cluster")
     else:

--- a/src/cardonnay/color_logger.py
+++ b/src/cardonnay/color_logger.py
@@ -1,0 +1,37 @@
+import logging
+import typing as tp
+
+from cardonnay import colors
+
+
+class ColorFormatter(logging.Formatter):
+    COLORS: tp.ClassVar[dict[str, str]] = {
+        "WARNING": colors.BColors.WARNING,
+        "ERROR": colors.BColors.FAIL,
+        "DEBUG": colors.BColors.OKBLUE,
+        # Keep "INFO" uncolored
+        "CRITICAL": colors.BColors.FAIL,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        color: str | None = self.COLORS.get(record.levelname)
+        if color:
+            record.name = f"{color}{record.name}{colors.BColors.ENDC}"
+            record.levelname = f"{color}{record.levelname}{colors.BColors.ENDC}"
+            record.msg = f"{color}{record.msg}{colors.BColors.ENDC}"
+        return super().format(record)
+
+
+def configure_logging(fmt: str | None = None) -> None:
+    fmt = fmt or "%(message)s"
+    logging.setLoggerClass(logging.Logger)  # Ensure standard logger is used
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)  # Set the global log level
+
+    # Remove existing handlers to avoid duplicates
+    while root_logger.handlers:
+        root_logger.handlers.pop()
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(ColorFormatter(fmt))
+    root_logger.addHandler(console_handler)

--- a/src/cardonnay/colors.py
+++ b/src/cardonnay/colors.py
@@ -1,0 +1,15 @@
+from cardonnay import helpers
+
+
+class BColors:
+    enable = helpers.should_use_color()
+
+    HEADER = "\033[95m" if enable else ""
+    OKBLUE = "\033[94m" if enable else ""
+    OKCYAN = "\033[96m" if enable else ""
+    OKGREEN = "\033[92m" if enable else ""
+    WARNING = "\033[93m" if enable else ""
+    FAIL = "\033[91m" if enable else ""
+    ENDC = "\033[0m" if enable else ""
+    BOLD = "\033[1m" if enable else ""
+    UNDERLINE = "\033[4m" if enable else ""

--- a/src/cardonnay/helpers.py
+++ b/src/cardonnay/helpers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import pathlib as pl
 import subprocess
 import sys
@@ -131,4 +132,14 @@ def wait_for_file(
 
         time.sleep(poll_interval)
 
+    return False
+
+
+def should_use_color() -> bool:
+    if "NO_COLOR" in os.environ:
+        return False
+    if os.environ.get("CLICOLOR_FORCE") == "1":
+        return True
+    if sys.stdout.isatty():
+        return os.environ.get("CLICOLOR", "1") != "0"
     return False

--- a/src/cardonnay/main.py
+++ b/src/cardonnay/main.py
@@ -9,6 +9,7 @@ from cardonnay import cli_control
 from cardonnay import cli_create
 from cardonnay import cli_inspect
 from cardonnay import cli_utils
+from cardonnay import color_logger
 
 LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def validate_comment(
 @click.group()
 def main() -> None:
     """Cardonnay - Cardano local testnets."""
-    logging.basicConfig(format="%(message)s", level=logging.INFO)
+    color_logger.configure_logging()
 
 
 @main.command(help="Create a local testnet.")


### PR DESCRIPTION
Introduce colorized output for CLI messages and logging. Add a new `colors` module with ANSI color codes, and a `color_logger` module for colorized log formatting. CLI commands now print status messages in green for better visibility. Color usage is configurable via environment variables: respects `NO_COLOR`, `CLICOLOR`, and `CLICOLOR_FORCE`.