### PR TITLE
refactor: centralize testnet state constants

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -8,6 +8,7 @@ import time
 
 from cardonnay import cli_utils
 from cardonnay import colors
+from cardonnay import consts
 from cardonnay import helpers
 
 LOGGER = logging.getLogger(__name__)
@@ -109,7 +110,11 @@ def print_instances(workdir: pl.Path) -> None:
         except Exception:
             testnet_info = {}
         testnet_name = testnet_info.get("name") or "unknown"
-        testnet_state = "started" if (statedir / cli_utils.STATUS_STARTED).exists() else "starting"
+        testnet_state = (
+            consts.States.STARTED
+            if (statedir / cli_utils.STATUS_STARTED).exists()
+            else consts.States.STARTING
+        )
         instance_info = {"instance": i, "type": testnet_name, "state": testnet_state}
         testnet_comment = testnet_info.get("comment")
         if testnet_comment:

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -6,6 +6,7 @@ import shutil
 import cardonnay_scripts
 from cardonnay import cli_utils
 from cardonnay import colors
+from cardonnay import consts
 from cardonnay import helpers
 from cardonnay import local_scripts
 
@@ -85,7 +86,7 @@ def testnet_start(
         instance_info = {
             "instance": instance_num,
             "type": testnet_variant,
-            "state": "starting",
+            "state": consts.States.STARTING,
             "pid": start_process.pid,
             "logfile": str(logfile),
         }

--- a/src/cardonnay/consts.py
+++ b/src/cardonnay/consts.py
@@ -1,0 +1,7 @@
+import typing as tp
+
+
+class States:
+    STARTED: tp.Final[str] = "started"
+    STARTING: tp.Final[str] = "starting"
+    STOPPED: tp.Final[str] = "stopped"

--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -5,6 +5,7 @@ import pathlib as pl
 import typing as tp
 
 from cardonnay import cli_utils
+from cardonnay import consts
 from cardonnay import helpers
 
 LOGGER = logging.getLogger(__name__)
@@ -107,9 +108,13 @@ def load_faucet_data(statedir: pl.Path) -> dict:
 def get_testnet_info(statedir: pl.Path) -> dict:
     """Get information about the testnet instance."""
     if (statedir / "supervisord.sock").exists():
-        testnet_state = "started" if (statedir / cli_utils.STATUS_STARTED).exists() else "starting"
+        testnet_state = (
+            consts.States.STARTED
+            if (statedir / cli_utils.STATUS_STARTED).exists()
+            else consts.States.STARTING
+        )
     else:
-        testnet_state = "stopped"
+        testnet_state = consts.States.STOPPED
 
     try:
         with open(statedir / cli_utils.TESTNET_JSON, encoding="utf-8") as fp_in:


### PR DESCRIPTION
Move testnet state strings ("started", "starting", "stopped") to a new consts.States class for consistency and maintainability. Update all references in cli_control.py, cli_create.py, and inspect_instance.py to use the new constants.