### PR TITLE
feat(cli): add stop-all command to stop all testnet instances

### DIFF
--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -182,3 +182,14 @@ def cmd_actions(
         return 1
 
     return 0
+
+
+def cmd_stopall(work_dir: str) -> int:
+    """Stop all running testnet instances."""
+    workdir = cli_utils.get_workdir(workdir=work_dir).absolute()
+    for i in cli_utils.get_running_instances(workdir=workdir):
+        kill_starting_testnet(pidfile=workdir / f"start_cluster{i}.pid")
+        statedir = workdir / f"state-cluster{i}"
+        env = cli_utils.create_env_vars(workdir=workdir, instance_num=i)
+        testnet_stop(statedir=statedir, env=env)
+    return 0

--- a/src/cardonnay/main.py
+++ b/src/cardonnay/main.py
@@ -177,11 +177,18 @@ def control_print_env(instance_num: int, work_dir: str) -> None:
 
 
 for name, help_text in [
-    ("stop", "Stop the running testnet."),
+    ("stop", "Stop the running testnet instance."),
     ("restart", "Restart all processes of the testnet."),
-    ("restart_nodes", "Restart only nodes of the testnet."),
+    ("restart_nodes", "Restart only node processes of the testnet."),
 ]:
     make_actions_cmd(name, help_text)
+
+
+@control.command(name="stop-all", help="Stop all running testnet instances.")
+@common_options_dir
+def control_stopall(work_dir: str) -> None:
+    retval = cli_control.cmd_stopall(work_dir=work_dir)
+    exit_with(retval)
 
 
 @main.group(help="Inspect a testnet instance.")


### PR DESCRIPTION
Introduce a new CLI command `stop-all` that stops all running testnet instances in the specified working directory. This command iterates over all running instances, kills their processes, and stops their testnets. Also, improve help texts for related commands for clarity.