### PR TITLE
feat(readme): add centered logo image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
+<p align="center">  <!-- markdownlint-disable-line MD033 -->
+  <img src="https://github.com/user-attachments/assets/c0c6b4ef-c647-4e77-952f-1ca9f4beaeec" alt="Cardonnay logo" width="200"/>  <!-- markdownlint-disable-line MD033 -->
+</p>
+
 TBD


### PR DESCRIPTION
Added a centered logo image to the README using HTML for alignment and custom width.

This PR also uploaded the actual image: 
![Cardonnay_logo](https://github.com/user-attachments/assets/c0c6b4ef-c647-4e77-952f-1ca9f4beaeec)
