### PR TITLE
feat: add bash completion script for cardonnay

### DIFF
--- a/completions/cardonnay.bash-completion
+++ b/completions/cardonnay.bash-completion
@@ -1,0 +1,3 @@
+# bash completion for cardonnay
+command -v cardonnay &> /dev/null && \
+  eval "$(_CARDONNAY_COMPLETE=bash_source cardonnay)"

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
                 source .venv_nix/bin/activate
                 export PYTHONPATH=$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):"$PYTHONPATH"
                 make install
-                eval "$(_CARDONNAY_COMPLETE=bash_source cardonnay)"
+                source completions/cardonnay.bash-completion
                 echo "Environment ready."
               '';
             };


### PR DESCRIPTION
Introduce a dedicated bash completion script for the cardonnay CLI in the completions directory. Update the development shell setup in flake.nix to source this script instead of evaluating the completion inline.