### PR TITLE
refactor(cli): unify instance info keys for start/inspect

### DIFF
--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -69,9 +69,10 @@ def testnet_start(
 
     cli_utils.set_env_vars(env=env)
 
+    logfile = workdir / f"start_cluster{instance_num}.log"
+    logfile.unlink(missing_ok=True)
+
     if background:
-        logfile = workdir / f"start_cluster{instance_num}.log"
-        logfile.unlink(missing_ok=True)
         start_process = helpers.run_detached_command(
             command=str(start_script), logfile=logfile, workdir=workdir
         )
@@ -87,8 +88,9 @@ def testnet_start(
             "instance": instance_num,
             "type": testnet_variant,
             "state": consts.States.STARTING,
-            "pid": start_process.pid,
-            "logfile": str(logfile),
+            "dir": str(statedir),
+            "start_pid": start_process.pid,
+            "start_logfile": str(logfile),
         }
         helpers.print_json(instance_info)
     else:

--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -123,10 +123,10 @@ def get_testnet_info(statedir: pl.Path) -> dict:
         testnet_info = {}
 
     testnet_name = testnet_info.get("name") or "unknown"
-    testnet_instance = int(statedir.name.replace("state-cluster", ""))
+    instance_num = int(statedir.name.replace("state-cluster", ""))
 
     instance_info = {
-        "instance": testnet_instance,
+        "instance": instance_num,
         "type": testnet_name,
         "state": testnet_state,
         "dir": str(statedir),
@@ -134,6 +134,20 @@ def get_testnet_info(statedir: pl.Path) -> dict:
     testnet_comment = testnet_info.get("comment")
     if testnet_comment:
         instance_info["comment"] = testnet_comment
+
+    workdir = statedir.parent
+
+    pidfile = workdir / f"start_cluster{instance_num}.pid"
+    if pidfile.exists() and testnet_state == consts.States.STARTING:
+        pid = 0
+        with contextlib.suppress(Exception):
+            pid = int(helpers.read_from_file(pidfile))
+        if pid:
+            instance_info["start_pid"] = pid
+
+    logfile = workdir / f"start_cluster{instance_num}.log"
+    if logfile.exists():
+        instance_info["start_logfile"] = str(logfile)
 
     return instance_info
 


### PR DESCRIPTION
Standardize the keys used for instance information in both the `testnet_start` and `get_testnet_info` functions. Replace "pid" and "logfile" with "start_pid" and "start_logfile" for consistency. Also, ensure the "dir" key is always present. This improves clarity and reduces confusion when consuming instance metadata.