### PR TITLE
feat(json): add colorized JSON output with pygments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "setuptools < 80.9",
     "supervisor",
     "click",
+    "pygments",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add pygments as a dependency and use it to colorize JSON output in print_json when appropriate. Introduce should_use_color to determine when to enable colored output, respecting NO_COLOR, CLICOLOR, and CLICOLOR_FORCE environment variables. This improves readability of JSON output in terminals that support color.