### PR TITLE
feat(json): support Path and datetime in JSON output

### DIFF
--- a/src/cardonnay/helpers.py
+++ b/src/cardonnay/helpers.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 import logging
 import os
@@ -5,6 +6,7 @@ import pathlib as pl
 import subprocess
 import sys
 import time
+import typing as tp
 
 import pygments
 from pygments.formatters import terminal as pterminal
@@ -13,6 +15,16 @@ from pygments.lexers import data as pdata
 from cardonnay import ttypes
 
 LOGGER = logging.getLogger(__name__)
+
+
+class CustomEncoder(json.JSONEncoder):
+    # pyrefly: ignore  # bad-override
+    def default(self, obj: tp.Any) -> tp.Any:  # noqa: ANN401
+        if isinstance(obj, pl.Path):
+            return str(obj)
+        if isinstance(obj, dt.datetime):
+            return obj.isoformat()
+        return super().default(obj)
 
 
 def should_use_color() -> bool:
@@ -34,7 +46,7 @@ def write_json(out_file: pl.Path, content: dict) -> pl.Path:
 
 def print_json(data: dict | list) -> None:
     """Print JSON data to stdout in a pretty format."""
-    json_str = json.dumps(data, indent=2)
+    json_str = json.dumps(data, cls=CustomEncoder, indent=2)
     if should_use_color():
         print(
             pygments.highlight(

--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -52,31 +52,31 @@ def load_pools_data(statedir: pl.Path) -> dict:
         pools_data[pool_data_dir.name] = {
             "payment": {
                 "address": helpers.read_from_file(pool_data_dir / "owner.addr"),
-                "vkey_file": str(pool_data_dir / "owner-utxo.vkey"),
-                "skey_file": str(pool_data_dir / "owner-utxo.skey"),
+                "vkey_file": pool_data_dir / "owner-utxo.vkey",
+                "skey_file": pool_data_dir / "owner-utxo.skey",
             },
             "stake": {
                 "address": helpers.read_from_file(pool_data_dir / "owner-stake.addr"),
-                "vkey_file": str(pool_data_dir / "owner-stake.vkey"),
-                "skey_file": str(pool_data_dir / "owner-stake.skey"),
+                "vkey_file": pool_data_dir / "owner-stake.vkey",
+                "skey_file": pool_data_dir / "owner-stake.skey",
             },
-            "stake_addr_registration_cert": str(pool_data_dir / "stake.reg.cert"),
-            "stake_addr_delegation_cert": str(pool_data_dir / "owner-stake.deleg.cert"),
-            "reward_addr_registration_cert": str(pool_data_dir / "stake-reward.reg.cert"),
-            "pool_registration_cert": str(pool_data_dir / "register.cert"),
-            "pool_operational_cert": str(pool_data_dir / "op.cert"),
+            "stake_addr_registration_cert": pool_data_dir / "stake.reg.cert",
+            "stake_addr_delegation_cert": pool_data_dir / "owner-stake.deleg.cert",
+            "reward_addr_registration_cert": pool_data_dir / "stake-reward.reg.cert",
+            "pool_registration_cert": pool_data_dir / "register.cert",
+            "pool_operational_cert": pool_data_dir / "op.cert",
             "cold_key_pair": {
-                "vkey_file": str(pool_data_dir / "cold.vkey"),
-                "skey_file": str(pool_data_dir / "cold.skey"),
-                "counter_file": str(pool_data_dir / "cold.counter"),
+                "vkey_file": pool_data_dir / "cold.vkey",
+                "skey_file": pool_data_dir / "cold.skey",
+                "counter_file": pool_data_dir / "cold.counter",
             },
             "vrf_key_pair": {
-                "vkey_file": str(pool_data_dir / "vrf.vkey"),
-                "skey_file": str(pool_data_dir / "vrf.skey"),
+                "vkey_file": pool_data_dir / "vrf.vkey",
+                "skey_file": pool_data_dir / "vrf.skey",
             },
             "kes_key_pair": {
-                "vkey_file": str(pool_data_dir / "kes.vkey"),
-                "skey_file": str(pool_data_dir / "kes.skey"),
+                "vkey_file": pool_data_dir / "kes.vkey",
+                "skey_file": pool_data_dir / "kes.skey",
             },
         }
 
@@ -92,14 +92,14 @@ def load_faucet_data(statedir: pl.Path) -> dict:
     if (byron_dir / "address-000-converted").exists():
         faucet_addrs_data["faucet"]["payment"] = {
             "address": helpers.read_from_file(byron_dir / "address-000-converted"),
-            "vkey_file": str(byron_dir / "payment-keys.000-converted.vkey"),
-            "skey_file": str(byron_dir / "payment-keys.000-converted.skey"),
+            "vkey_file": byron_dir / "payment-keys.000-converted.vkey",
+            "skey_file": byron_dir / "payment-keys.000-converted.skey",
         }
     elif (shelley_dir / "genesis-utxo.addr").exists():
         faucet_addrs_data["faucet"]["payment"] = {
             "address": helpers.read_from_file(shelley_dir / "genesis-utxo.addr"),
-            "vkey_file": str(shelley_dir / "genesis-utxo.vkey"),
-            "skey_file": str(shelley_dir / "genesis-utxo.skey"),
+            "vkey_file": shelley_dir / "genesis-utxo.vkey",
+            "skey_file": shelley_dir / "genesis-utxo.skey",
         }
 
     return faucet_addrs_data
@@ -129,7 +129,7 @@ def get_testnet_info(statedir: pl.Path) -> dict:
         "instance": instance_num,
         "type": testnet_name,
         "state": testnet_state,
-        "dir": str(statedir),
+        "dir": statedir,
     }
     testnet_comment = testnet_info.get("comment")
     if testnet_comment:
@@ -147,7 +147,7 @@ def get_testnet_info(statedir: pl.Path) -> dict:
 
     logfile = workdir / f"start_cluster{instance_num}.log"
     if logfile.exists():
-        instance_info["start_logfile"] = str(logfile)
+        instance_info["start_logfile"] = logfile
 
     return instance_info
 


### PR DESCRIPTION
Add a CustomEncoder for JSON serialization that handles pathlib.Path and datetime.datetime objects, converting them to string and ISO format respectively. Update usages in inspect_instance.py to store Path objects directly in data structures, relying on the new encoder for correct serialization. This improves consistency and enables richer data handling when printing or writing JSON.