### PR TITLE
fix(cli): prevent create with custom workdir if default running

### DIFF
--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -150,6 +150,14 @@ def cmd_create(  # noqa: PLR0911, C901
         )
         return 1
 
+    if work_dir and (
+        run_inst_default := ca_utils.get_running_instances(workdir=ca_utils.get_workdir(workdir=""))
+    ):
+        run_insts_str = ",".join(sorted(str(i) for i in run_inst_default))
+        LOGGER.error(f"Instances running in the default workdir '{work_dir}': {run_insts_str}")
+        LOGGER.error("Stop them first before using custom work dir.")
+        return 1
+
     workdir = ca_utils.get_workdir(workdir=work_dir)
     workdir_abs = workdir.absolute()
 


### PR DESCRIPTION
If a custom work directory is specified and there are running instances in the default workdir, the command now aborts with an error. This prevents conflicts and ensures users stop default instances before proceeding with a custom workdir.