### PR TITLE
fix(instance): make start_pid optional if not positive

### DIFF
--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -184,7 +184,7 @@ def get_testnet_info(statedir: pl.Path) -> structs.InstanceInfo:
         state=testnet_state,
         dir=statedir,
         comment=testnet_info.get("comment"),
-        start_pid=start_pid,
+        start_pid=start_pid if start_pid > 0 else None,
         start_logfile=start_logfile,
         control_env=get_control_env(statedir=statedir),
         supervisor_env=get_supervisor_env(statedir=statedir),

--- a/src/cardonnay/structs.py
+++ b/src/cardonnay/structs.py
@@ -45,7 +45,7 @@ class InstanceInfo(pydantic.BaseModel):
     state: str
     dir: pl.Path
     comment: str | None
-    start_pid: int
+    start_pid: int | None
     start_logfile: pl.Path | None
     control_env: dict[str, str]
     supervisor_env: SupervisorData


### PR DESCRIPTION
Previously, start_pid was always set as an integer, even if its value was not positive, which could lead to confusion or errors when a valid PID was not available. This change updates the InstanceInfo model to allow start_pid to be None, and ensures that get_testnet_info sets start_pid to None if it is not greater than zero. This improves clarity and correctness in representing the absence of a process ID.