### PR TITLE
fix(inspect_instance): normalize supervisor.conf line endings

### DIFF
--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -130,7 +130,7 @@ def get_supervisor_env(statedir: pl.Path) -> structs.SupervisorData:
         contextlib.suppress(Exception),
         open(statedir / "supervisor.conf", encoding="utf-8") as fp_in,
     ):
-        supervisor_conf = set(fp_in.readlines())
+        supervisor_conf = {line.rstrip("\r\n") for line in fp_in}
 
     supervisor_data = structs.SupervisorData(
         HAS_DBSYNC="[program:dbsync]" in supervisor_conf,


### PR DESCRIPTION
Replace set(readlines()) with a set comprehension that strips trailing carriage return and newline characters from each line in supervisor.conf. This ensures consistent line comparison regardless of platform-specific line endings and prevents subtle bugs when checking for program entries.