### PR TITLE
feat: add submit_api_port to InstanceInfo and extraction logic

### DIFF
--- a/src/cardonnay/structs.py
+++ b/src/cardonnay/structs.py
@@ -45,6 +45,7 @@ class InstanceInfo(pydantic.BaseModel):
     state: str
     dir: pl.Path
     comment: str | None
+    submit_api_port: int | None
     start_pid: int | None
     start_logfile: pl.Path | None
     control_env: dict[str, str]


### PR DESCRIPTION
- Introduce `get_submit_api_port` to extract the Submit API port from the `run-cardano-submit-api` file using regex.
- Add `submit_api_port` field to `InstanceInfo` model.
- Populate `submit_api_port` in `get_testnet_info` if available, otherwise set to None.