### PR TITLE
refactor: unify workdir argument naming across modules

### DIFF
--- a/src/cardonnay/ca_utils.py
+++ b/src/cardonnay/ca_utils.py
@@ -25,7 +25,7 @@ def set_env_vars(env: dict[str, str]) -> None:
 
 def get_workdir(workdir: ttypes.FileType) -> pl.Path:
     if workdir != "":
-        return pl.Path(workdir)
+        return pl.Path(workdir).expanduser()
 
     return pl.Path("/var/tmp/cardonnay")
 

--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -136,49 +136,48 @@ def print_env_sh(env: dict[str, str]) -> None:
 
 
 def cmd_print_env(
-    work_dir: str,
+    workdir: str,
     instance_num: int,
 ) -> int:
     """Print environment variables for the specified testnet instance."""
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
 
     if instance_num < 0:
         LOGGER.error("Valid instance number is required.")
         return 1
 
-    env = ca_utils.create_env_vars(workdir=workdir, instance_num=instance_num)
+    env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=instance_num)
 
     print_env_sh(env=env)
 
     return 0
 
 
-def cmd_ls(work_dir: str) -> int:
+def cmd_ls(workdir: str) -> int:
     """List all running testnet instances."""
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    print_instances(workdir=workdir)
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    print_instances(workdir=workdir_pl)
     return 0
 
 
 def cmd_actions(
-    work_dir: str,
+    workdir: str,
     instance_num: int,
     stop: bool = False,
     restart: bool = False,
     restart_nodes: bool = False,
 ) -> int:
     """Perform actions on a testnet instance."""
-    workdir = ca_utils.get_workdir(workdir=work_dir)
-    workdir_abs = workdir.absolute()
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
 
     if instance_num < 0:
         LOGGER.error("Valid instance number is required.")
         return 1
 
-    statedir = workdir_abs / f"state-cluster{instance_num}"
-    env = ca_utils.create_env_vars(workdir=workdir_abs, instance_num=instance_num)
+    statedir = workdir_pl / f"state-cluster{instance_num}"
+    env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=instance_num)
 
-    if instance_num not in ca_utils.get_running_instances(workdir=workdir_abs):
+    if instance_num not in ca_utils.get_running_instances(workdir=workdir_pl):
         LOGGER.error("Instance is not running.")
         return 1
 
@@ -186,7 +185,7 @@ def cmd_actions(
         return 1
 
     if stop:
-        kill_starting_testnet(pidfile=workdir_abs / f"start_cluster{instance_num}.pid")
+        kill_starting_testnet(pidfile=workdir_pl / f"start_cluster{instance_num}.pid")
         testnet_stop(statedir=statedir, env=env)
     elif restart:
         testnet_restart_all(statedir=statedir, env=env)
@@ -199,12 +198,12 @@ def cmd_actions(
     return 0
 
 
-def cmd_stopall(work_dir: str) -> int:
+def cmd_stopall(workdir: str) -> int:
     """Stop all running testnet instances."""
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    for i in ca_utils.get_running_instances(workdir=workdir):
-        kill_starting_testnet(pidfile=workdir / f"start_cluster{i}.pid")
-        statedir = workdir / f"state-cluster{i}"
-        env = ca_utils.create_env_vars(workdir=workdir, instance_num=i)
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    for i in ca_utils.get_running_instances(workdir=workdir_pl):
+        kill_starting_testnet(pidfile=workdir_pl / f"start_cluster{i}.pid")
+        statedir = workdir_pl / f"state-cluster{i}"
+        env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=i)
         testnet_stop(statedir=statedir, env=env)
     return 0

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -120,7 +120,7 @@ def cmd_create(  # noqa: PLR0911, C901
     keep: bool,
     stake_pools_num: int,
     ports_base: int,
-    work_dir: str,
+    workdir: str,
     instance_num: int,
     verbose: int,
 ) -> int:
@@ -141,16 +141,16 @@ def cmd_create(  # noqa: PLR0911, C901
         )
         return 1
 
-    if work_dir and (
+    if workdir and (
         run_inst_default := ca_utils.get_running_instances(workdir=ca_utils.get_workdir(workdir=""))
     ):
         run_insts_str = ",".join(sorted(str(i) for i in run_inst_default))
-        LOGGER.error(f"Instances running in the default workdir '{work_dir}': {run_insts_str}")
+        LOGGER.error(f"Instances running in the default workdir '{workdir}': {run_insts_str}")
         LOGGER.error("Stop them first before using custom work dir.")
         return 1
 
-    workdir = ca_utils.get_workdir(workdir=work_dir)
-    workdir_abs = workdir.absolute()
+    workdir_pl = ca_utils.get_workdir(workdir=workdir)
+    workdir_abs = workdir_pl.absolute()
 
     avail_instances_gen = ca_utils.get_available_instances(workdir=workdir_abs)
     if instance_num < 0:
@@ -162,7 +162,7 @@ def cmd_create(  # noqa: PLR0911, C901
     elif instance_num not in avail_instances_gen:
         LOGGER.error(f"Instance number {instance_num} is already in use.")
         return 1
-    destdir = workdir / f"cluster{instance_num}_{testnet_variant}"
+    destdir = workdir_pl / f"cluster{instance_num}_{testnet_variant}"
     destdir_abs = destdir.absolute()
 
     if not keep:
@@ -199,7 +199,7 @@ def cmd_create(  # noqa: PLR0911, C901
             f"🚀 {colors.BColors.OKGREEN}You can now start the testnet cluster "
             f"with:{colors.BColors.ENDC}"
         )
-        print(f"source {workdir}/.source_cluster{instance_num}")
+        print(f"source {workdir_pl}/.source_cluster{instance_num}")
         print(f"{destdir}/start-cluster")
     else:
         run_retval = testnet_start(

--- a/src/cardonnay/cli_inspect.py
+++ b/src/cardonnay/cli_inspect.py
@@ -23,9 +23,9 @@ def check_prereq(
     return 0
 
 
-def cmd_faucet(work_dir: str, instance_num: int) -> int:
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    statedir = workdir / f"state-cluster{instance_num}"
+def cmd_faucet(workdir: str, instance_num: int) -> int:
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    statedir = workdir_pl / f"state-cluster{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -34,9 +34,9 @@ def cmd_faucet(work_dir: str, instance_num: int) -> int:
     return 0
 
 
-def cmd_pools(work_dir: str, instance_num: int) -> int:
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    statedir = workdir / f"state-cluster{instance_num}"
+def cmd_pools(workdir: str, instance_num: int) -> int:
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    statedir = workdir_pl / f"state-cluster{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -48,9 +48,9 @@ def cmd_pools(work_dir: str, instance_num: int) -> int:
     return 0
 
 
-def cmd_status(work_dir: str, instance_num: int) -> int:
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    statedir = workdir / f"state-cluster{instance_num}"
+def cmd_status(workdir: str, instance_num: int) -> int:
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    statedir = workdir_pl / f"state-cluster{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -59,9 +59,9 @@ def cmd_status(work_dir: str, instance_num: int) -> int:
     return 0
 
 
-def cmd_config(work_dir: str, instance_num: int) -> int:
-    workdir = ca_utils.get_workdir(workdir=work_dir).absolute()
-    statedir = workdir / f"state-cluster{instance_num}"
+def cmd_config(workdir: str, instance_num: int) -> int:
+    workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
+    statedir = workdir_pl / f"state-cluster{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret

--- a/src/cardonnay/helpers.py
+++ b/src/cardonnay/helpers.py
@@ -40,7 +40,7 @@ def should_use_color() -> bool:
 
 def write_json(out_file: pl.Path, content: dict) -> pl.Path:
     """Write dictionary content to JSON file."""
-    with open(out_file.expanduser(), "w", encoding="utf-8") as out_fp:
+    with open(out_file, "w", encoding="utf-8") as out_fp:
         out_fp.write(json.dumps(content, indent=4))
     return out_file
 
@@ -144,7 +144,7 @@ def run_detached_command(
 
 def read_from_file(file: ttypes.FileType) -> str:
     """Read address stored in file."""
-    with open(pl.Path(file).expanduser(), encoding="utf-8") as in_file:
+    with open(pl.Path(file), encoding="utf-8") as in_file:
         return in_file.read().strip()
 
 

--- a/src/cardonnay/main.py
+++ b/src/cardonnay/main.py
@@ -138,7 +138,7 @@ def create(
         keep=keep,
         stake_pools_num=stake_pools_num,
         ports_base=ports_base,
-        work_dir=work_dir,
+        workdir=work_dir,
         instance_num=instance_num,
         verbose=verbose,
     )
@@ -157,7 +157,7 @@ def make_actions_cmd(flag_name: str, help_text: str) -> None:
     def cmd(instance_num: int, work_dir: str) -> None:
         retval = cli_control.cmd_actions(
             **{flag_name: True},
-            work_dir=work_dir,
+            workdir=work_dir,
             instance_num=instance_num,
         )
         exit_with(retval)
@@ -166,7 +166,7 @@ def make_actions_cmd(flag_name: str, help_text: str) -> None:
 @control.command(name="ls", help="List running testnet instances.")
 @common_options_dir
 def control_ls(work_dir: str) -> None:
-    retval = cli_control.cmd_ls(work_dir=work_dir)
+    retval = cli_control.cmd_ls(workdir=work_dir)
     exit_with(retval)
 
 
@@ -174,7 +174,7 @@ def control_ls(work_dir: str) -> None:
 @common_options_instance
 @common_options_dir
 def control_print_env(instance_num: int, work_dir: str) -> None:
-    retval = cli_control.cmd_print_env(work_dir=work_dir, instance_num=instance_num)
+    retval = cli_control.cmd_print_env(workdir=work_dir, instance_num=instance_num)
     exit_with(retval)
 
 
@@ -189,7 +189,7 @@ for name, help_text in [
 @control.command(name="stop-all", help="Stop all running testnet instances.")
 @common_options_dir
 def control_stopall(work_dir: str) -> None:
-    retval = cli_control.cmd_stopall(work_dir=work_dir)
+    retval = cli_control.cmd_stopall(workdir=work_dir)
     exit_with(retval)
 
 
@@ -203,7 +203,7 @@ def inspect() -> None:
 @common_options_dir
 def inspect_faucet(instance_num: int, work_dir: str) -> None:
     retval = cli_inspect.cmd_faucet(
-        work_dir=work_dir,
+        workdir=work_dir,
         instance_num=instance_num,
     )
     exit_with(retval)
@@ -214,7 +214,7 @@ def inspect_faucet(instance_num: int, work_dir: str) -> None:
 @common_options_dir
 def inspect_pools(instance_num: int, work_dir: str) -> None:
     retval = cli_inspect.cmd_pools(
-        work_dir=work_dir,
+        workdir=work_dir,
         instance_num=instance_num,
     )
     exit_with(retval)
@@ -225,7 +225,7 @@ def inspect_pools(instance_num: int, work_dir: str) -> None:
 @common_options_dir
 def inspect_status(instance_num: int, work_dir: str) -> None:
     retval = cli_inspect.cmd_status(
-        work_dir=work_dir,
+        workdir=work_dir,
         instance_num=instance_num,
     )
     exit_with(retval)
@@ -236,7 +236,7 @@ def inspect_status(instance_num: int, work_dir: str) -> None:
 @common_options_dir
 def inspect_config(instance_num: int, work_dir: str) -> None:
     retval = cli_inspect.cmd_config(
-        work_dir=work_dir,
+        workdir=work_dir,
         instance_num=instance_num,
     )
     exit_with(retval)


### PR DESCRIPTION
Standardize the naming of the work directory argument from `work_dir` to `workdir` across all CLI modules and function signatures. This improves consistency and reduces confusion when passing or referencing the work directory parameter. Also, update all internal variable names and usage to match the new convention.