### PR TITLE
fix(makefile): remove install_dev target and update install

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python3 -m venv .venv
         source .venv/bin/activate
-        make install_dev
+        make install
     - name: Load cached pre-commit env
       id: cached-pre-commit
       uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 .PHONY: install
 install:
 	python3 -m pip install --require-virtualenv --upgrade pip
-	python3 -m pip install --require-virtualenv --upgrade -e . $(PIP_INSTALL_ARGS)
-
-.PHONY: install_dev
-install_dev:
-	python3 -m pip install --require-virtualenv --upgrade pip
 	python3 -m pip install --require-virtualenv --upgrade -r requirements-dev.txt $(PIP_INSTALL_ARGS)
 
 # run linters

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
                 [ -e .venv_nix ] || python3 -m venv .venv_nix
                 source .venv_nix/bin/activate
                 export PYTHONPATH=$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):"$PYTHONPATH"
-                make install
+                python3 -m pip install --require-virtualenv --upgrade -e .
                 source completions/cardonnay.bash-completion
                 echo "Environment ready."
               '';


### PR DESCRIPTION
The Makefile no longer includes a separate install_dev target. The install target now installs development dependencies by default using requirements-dev.txt.