### PR TITLE
fix(readme): update pip install command for safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # Install Cardonnay
-pip install cardonnay
+pip install -U --require-virtualenv cardonnay
 
 # (Optional) Enable shell completions for Bash
 source completions/cardonnay.bash-completion


### PR DESCRIPTION
Change pip install instructions to use -U and --require-virtualenv flags. This ensures users upgrade Cardonnay if already installed and prevents accidental global installations outside a virtual environment.