### PR TITLE
chore(scripts): remove nix shebang from postgres-setup.sh

### DIFF
--- a/src/cardonnay_scripts/scripts/conway_fast/postgres-setup.sh
+++ b/src/cardonnay_scripts/scripts/conway_fast/postgres-setup.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env -S nix develop --accept-flake-config github:IntersectMBO/cardano-node-tests#postgres -i -k CARDANO_NODE_SOCKET_PATH -k PGHOST -k PGPORT -k PGUSER --no-write-lock-file -c bash
-# shellcheck shell=bash
+#! /usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/cardonnay_scripts/scripts/conway_slow/postgres-setup.sh
+++ b/src/cardonnay_scripts/scripts/conway_slow/postgres-setup.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env -S nix develop --accept-flake-config github:IntersectMBO/cardano-node-tests#postgres -i -k CARDANO_NODE_SOCKET_PATH -k PGHOST -k PGPORT -k PGUSER --no-write-lock-file -c bash
-# shellcheck shell=bash
+#! /usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/cardonnay_scripts/scripts/mainnet_fast/postgres-setup.sh
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/postgres-setup.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env -S nix develop --accept-flake-config github:IntersectMBO/cardano-node-tests#postgres -i -k CARDANO_NODE_SOCKET_PATH -k PGHOST -k PGPORT -k PGUSER --no-write-lock-file -c bash
-# shellcheck shell=bash
+#! /usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Replaced the nix develop shebang with a standard bash shebang in all postgres-setup.sh scripts under conway_fast, conway_slow, and mainnet_fast.