### PR TITLE
feat(scripts): check CARDANO_NODE_SOCKET_PATH in cluster scripts

### DIFF
--- a/src/cardonnay_scripts/scripts/common/postgres-setup.sh
+++ b/src/cardonnay_scripts/scripts/common/postgres-setup.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  exit 1
+fi
+
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 INSTANCE_NUM="${STATE_CLUSTER#*state-cluster}"

--- a/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
@@ -2,6 +2,19 @@
 
 set -uo pipefail
 
+retval=0
+
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  retval=1
+fi
+if [ -z "${DBSYNC_REPO:-}" ]; then
+  echo "DBSYNC_REPO is not set" >&2
+  retval=1
+fi
+if [ "$retval" -ne 0 ]; then
+  exit "$retval"
+fi
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"

--- a/src/cardonnay_scripts/scripts/common/run-cardano-smash
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-smash
@@ -2,6 +2,20 @@
 
 set -uo pipefail
 
+retval=0
+
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  retval=1
+fi
+if [ -z "${DBSYNC_REPO:-}" ]; then
+  echo "DBSYNC_REPO is not set" >&2
+  retval=1
+fi
+if [ "$retval" -ne 0 ]; then
+  exit "$retval"
+fi
+
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"

--- a/src/cardonnay_scripts/scripts/common/start-cluster
+++ b/src/cardonnay_scripts/scripts/common/start-cluster
@@ -3,6 +3,11 @@
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"

--- a/src/cardonnay_scripts/scripts/common/stop-cluster
+++ b/src/cardonnay_scripts/scripts/common/stop-cluster
@@ -2,6 +2,11 @@
 
 set -uo pipefail
 
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  exit 1
+fi
+
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 PID_FILE="${STATE_CLUSTER}/supervisord.pid"

--- a/src/cardonnay_scripts/scripts/conway_slow/start-cluster
+++ b/src/cardonnay_scripts/scripts/conway_slow/start-cluster
@@ -3,6 +3,11 @@
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO"' ERR
 
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"


### PR DESCRIPTION
Add explicit checks for CARDANO_NODE_SOCKET_PATH in cluster-related scripts to ensure the variable is set before proceeding. This prevents unexpected errors due to unset environment variables and improves script robustness. Also, add DBSYNC_REPO checks in dbsync and smash scripts for completeness.