### PR TITLE
refactor(scripts): use DBSYNC_SCHEMA var and binaries in PATH

### DIFF
--- a/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
@@ -8,13 +8,14 @@ if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
   echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
   retval=1
 fi
-if [ -z "${DBSYNC_REPO:-}" ]; then
-  echo "DBSYNC_REPO is not set" >&2
+if [ -z "${DBSYNC_SCHEMA_DIR:-}" ]; then
+  echo "DBSYNC_SCHEMA_DIR is not set" >&2
   retval=1
 fi
 if [ "$retval" -ne 0 ]; then
   exit "$retval"
 fi
+
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
@@ -24,4 +25,4 @@ export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-exec "$DBSYNC_REPO/db-sync-node/bin/cardano-db-sync" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_REPO/schema"
+exec cardano-db-sync --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_SCHEMA_DIR"

--- a/src/cardonnay_scripts/scripts/common/run-cardano-smash
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-smash
@@ -2,18 +2,9 @@
 
 set -uo pipefail
 
-retval=0
-
 if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
   echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
-  retval=1
-fi
-if [ -z "${DBSYNC_REPO:-}" ]; then
-  echo "DBSYNC_REPO is not set" >&2
-  retval=1
-fi
-if [ "$retval" -ne 0 ]; then
-  exit "$retval"
+  exit 1
 fi
 
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
@@ -27,4 +18,4 @@ export SMASH_ADMINS_FILE="$STATE_CLUSTER/admins.txt"
 
 echo "${SMASH_ADMIN}, ${SMASH_PASSWORD}" > "$SMASH_ADMINS_FILE"
 
-exec "$DBSYNC_REPO/smash-server/bin/cardano-smash-server" --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --port %%SMASH_PORT%% --admins "$SMASH_ADMINS_FILE"
+exec cardano-smash-server --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --port %%SMASH_PORT%% --admins "$SMASH_ADMINS_FILE"

--- a/src/cardonnay_scripts/scripts/common/start-cluster
+++ b/src/cardonnay_scripts/scripts/common/start-cluster
@@ -118,9 +118,9 @@ serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
 EoF
 
 # enable db-sync service
-if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync" ] || \
-    { echo "The \`${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
+if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+  command -v cardano-db-sync > /dev/null 2>&1 || \
+    { echo "The \`cardano-db-sync\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   if [ -z "${DRY_RUN:-""}" ]; then
@@ -140,9 +140,9 @@ EoF
 fi
 
 # enable smash service
-if [ -n "${DBSYNC_REPO:-""}" ] && [ -n "${SMASH:-""}" ]; then
-  [ -e "${DBSYNC_REPO}/smash-server/bin/cardano-smash-server" ] || \
-    { echo "The \`${DBSYNC_REPO}/smash-server/bin/cardano-smash-server\` not found, line $LINENO" >&2; exit 1; }  # assert
+if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+  command -v cardano-smash-server > /dev/null 2>&1 || \
+    { echo "The \`cardano-smash-server\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
   cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
@@ -587,13 +587,13 @@ done
 
 
 # start db-sync
-if [ -n "${DBSYNC_REPO:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
   echo "Starting db-sync"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 # start smash
-if [ -n "${DBSYNC_REPO:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
   echo "Starting smash"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start smash
 fi

--- a/src/cardonnay_scripts/scripts/conway_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/conway_fast/testnet.json
@@ -2,7 +2,7 @@
     "name": "conway_fast",
     "description": "Local testnet that starts directly in Conway era.",
     "control_env": {
-        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",

--- a/src/cardonnay_scripts/scripts/conway_slow/start-cluster
+++ b/src/cardonnay_scripts/scripts/conway_slow/start-cluster
@@ -116,9 +116,9 @@ serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
 EoF
 
 # enable db-sync service
-if [ -n "${DBSYNC_REPO:-""}" ]; then
-  [ -e "${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync" ] || \
-    { echo "The \`${DBSYNC_REPO}/db-sync-node/bin/cardano-db-sync\` not found, line $LINENO" >&2; exit 1; }  # assert
+if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+  command -v cardano-db-sync > /dev/null 2>&1 || \
+    { echo "The \`cardano-db-sync\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
   # create clean database
   if [ -z "${DRY_RUN:-""}" ]; then
@@ -138,9 +138,9 @@ EoF
 fi
 
 # enable smash service
-if [ -n "${DBSYNC_REPO:-""}" ] && [ -n "${SMASH:-""}" ]; then
-  [ -e "${DBSYNC_REPO}/smash-server/bin/cardano-smash-server" ] || \
-    { echo "The \`${DBSYNC_REPO}/smash-server/bin/cardano-smash-server\` not found, line $LINENO" >&2; exit 1; }  # assert
+if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+  command -v cardano-smash-server > /dev/null 2>&1 || \
+    { echo "The \`cardano-smash-server\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
   cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 [program:smash]
@@ -797,13 +797,13 @@ wait_for_era "Shelley"
 SHELLEY_EPOCH="$(get_epoch)"
 
 # start db-sync
-if [ -n "${DBSYNC_REPO:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
   echo "Starting db-sync"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 # start smash
-if [ -n "${DBSYNC_REPO:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
   echo "Starting smash"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start smash
 fi

--- a/src/cardonnay_scripts/scripts/conway_slow/testnet.json
+++ b/src/cardonnay_scripts/scripts/conway_slow/testnet.json
@@ -2,7 +2,7 @@
     "name": "conway_slow",
     "description": "Local testnet that starts in Byron era and hard-forks through all the protocol versions until it gets to Conway.",
     "control_env": {
-        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",

--- a/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
@@ -2,7 +2,7 @@
     "name": "mainnet_fast",
     "description": "Local testnet that starts directly in Conway era and has the same epoch length as Mainnet.",
     "control_env": {
-        "DBSYNC_REPO": "will start and configure db-sync if the value is path to db-sync repository",
+        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",


### PR DESCRIPTION
Replace usage of DBSYNC_REPO with DBSYNC_SCHEMA to specify the db-sync schema directory, and update scripts to call cardano-db-sync and cardano-smash-server from PATH instead of using binaries from a repo directory. Update environment variable documentation in testnet.json files accordingly. This simplifies configuration and improves compatibility with system-installed binaries.