### PR TITLE
refactor(env): rename DBSYNC_SCHEMA to DBSYNC_SCHEMA_DIR

### DIFF
--- a/src/cardonnay_scripts/scripts/common/start-cluster
+++ b/src/cardonnay_scripts/scripts/common/start-cluster
@@ -118,7 +118,7 @@ serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
 EoF
 
 # enable db-sync service
-if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ]; then
   command -v cardano-db-sync > /dev/null 2>&1 || \
     { echo "The \`cardano-db-sync\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
@@ -140,7 +140,7 @@ EoF
 fi
 
 # enable smash service
-if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ] && [ -n "${SMASH:-""}" ]; then
   command -v cardano-smash-server > /dev/null 2>&1 || \
     { echo "The \`cardano-smash-server\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
@@ -587,13 +587,13 @@ done
 
 
 # start db-sync
-if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ]; then
   echo "Starting db-sync"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 # start smash
-if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ] && [ -n "${SMASH:-""}" ]; then
   echo "Starting smash"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start smash
 fi

--- a/src/cardonnay_scripts/scripts/conway_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/conway_fast/testnet.json
@@ -2,7 +2,7 @@
     "name": "conway_fast",
     "description": "Local testnet that starts directly in Conway era.",
     "control_env": {
-        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
+        "DBSYNC_SCHEMA_DIR": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",

--- a/src/cardonnay_scripts/scripts/conway_slow/start-cluster
+++ b/src/cardonnay_scripts/scripts/conway_slow/start-cluster
@@ -116,7 +116,7 @@ serverurl = unix:///${SUPERVISORD_SOCKET_PATH}
 EoF
 
 # enable db-sync service
-if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ]; then
   command -v cardano-db-sync > /dev/null 2>&1 || \
     { echo "The \`cardano-db-sync\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
@@ -138,7 +138,7 @@ EoF
 fi
 
 # enable smash service
-if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ] && [ -n "${SMASH:-""}" ]; then
   command -v cardano-smash-server > /dev/null 2>&1 || \
     { echo "The \`cardano-smash-server\` binary not found, line $LINENO" >&2; exit 1; }  # assert
 
@@ -797,13 +797,13 @@ wait_for_era "Shelley"
 SHELLEY_EPOCH="$(get_epoch)"
 
 # start db-sync
-if [ -n "${DBSYNC_SCHEMA:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ]; then
   echo "Starting db-sync"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start dbsync
 fi
 
 # start smash
-if [ -n "${DBSYNC_SCHEMA:-""}" ] && [ -n "${SMASH:-""}" ]; then
+if [ -n "${DBSYNC_SCHEMA_DIR:-""}" ] && [ -n "${SMASH:-""}" ]; then
   echo "Starting smash"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start smash
 fi

--- a/src/cardonnay_scripts/scripts/conway_slow/testnet.json
+++ b/src/cardonnay_scripts/scripts/conway_slow/testnet.json
@@ -2,7 +2,7 @@
     "name": "conway_slow",
     "description": "Local testnet that starts in Byron era and hard-forks through all the protocol versions until it gets to Conway.",
     "control_env": {
-        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
+        "DBSYNC_SCHEMA_DIR": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",

--- a/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
@@ -2,7 +2,7 @@
     "name": "mainnet_fast",
     "description": "Local testnet that starts directly in Conway era and has the same epoch length as Mainnet.",
     "control_env": {
-        "DBSYNC_SCHEMA": "will start and configure db-sync if the value is path to db-sync schema directory",
+        "DBSYNC_SCHEMA_DIR": "will start and configure db-sync if the value is path to db-sync schema directory",
         "SMASH": "if set, will start and configure smash",
         "ENABLE_LEGACY": "if set, local cluster will use legacy networking",
         "MIXED_P2P": "if set, local cluster will use P2P for some nodes and legacy topology for others",


### PR DESCRIPTION
Renamed the environment variable `DBSYNC_SCHEMA` to `DBSYNC_SCHEMA_DIR` in cluster start scripts and testnet configuration files. This clarifies that the variable should contain the path to the db-sync schema directory. Updated all relevant checks and documentation to use the new variable name.