### PR TITLE
feat(cli): track early start instances and add StartInfo

### DIFF
--- a/src/cardonnay/structs.py
+++ b/src/cardonnay/structs.py
@@ -52,6 +52,14 @@ class InstanceInfo(pydantic.BaseModel):
     supervisor_env: SupervisorData
 
 
+class StartInfo(pydantic.BaseModel):
+    instance: int
+    type: str
+    dir: pl.Path
+    start_pid: int | None
+    start_logfile: pl.Path | None
+
+
 class InstanceSummary(pydantic.BaseModel):
     instance: int
     type: str


### PR DESCRIPTION
Add logic to detect and track instances that are in the process of starting but not yet fully initialized, using status files with a short validity window. Introduce a StartInfo struct to provide information about the starting testnet instance, including PID and logfile. Prevents race conditions when allocating instances and improves reporting of start status.