### PR TITLE
fix(devshell): rename venv dir to .nix_venv in shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,8 @@
               ];
               shellHook = ''
                 echo "Setting up environment..."
-                [ -e .venv_nix ] || python3 -m venv .venv_nix
-                source .venv_nix/bin/activate
+                [ -e .nix_venv ] || python3 -m venv .nix_venv
+                source .nix_venv/bin/activate
                 export PYTHONPATH=$(echo "$VIRTUAL_ENV"/lib/python3*/site-packages):"$PYTHONPATH"
                 python3 -m pip install --require-virtualenv --upgrade -e .
                 source completions/cardonnay.bash-completion


### PR DESCRIPTION
Renamed the Python virtual environment directory from .venv_nix to .nix_venv in the devShell shellHook. Pyrefly seems to prefer `.venv_nix` over `.venv` and fails on discovering Python modules.