### PR TITLE
feat: add filelock-based instance delay for testnets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "click >= 7.0",
     "pygments >= 2.0",
     "pydantic >= 2.0",
+    "filelock >= 3.0"
 ]
 
 [project.urls]

--- a/src/cardonnay/ca_utils.py
+++ b/src/cardonnay/ca_utils.py
@@ -2,7 +2,10 @@ import logging
 import os
 import pathlib as pl
 import shutil
+import time
 import typing as tp
+
+import filelock
 
 from cardonnay import ttypes
 
@@ -11,6 +14,8 @@ LOGGER = logging.getLogger(__name__)
 MAX_INSTANCES = 10
 TESTNET_JSON = "testnet.json"
 STATUS_STARTED = "status_started"
+DELAY_STATUS = "delay_stat"
+DELAY_LOCK = "delay.lock"
 
 
 def create_env_vars(workdir: pl.Path, instance_num: int) -> dict[str, str]:
@@ -60,3 +65,48 @@ def check_env_sanity() -> bool:
 
 def has_supervisorctl() -> bool:
     return has_bins(bins=["supervisorctl"])
+
+
+def get_delay_instances(workdir: pl.Path) -> set[int]:
+    """Get the set of instances that are currently delayed based on file modification time.
+
+    An instance can be in a state where it is starting, but the supervisord.sock was not
+    created yet, so it is not considered as properly "starting" yet.
+    Or an instance can be in a state where it is stopping, but the supervisord.sock is still
+    present, so it is not considered as properly stopped yet.
+    """
+    valid_time_sec = 10
+    starting = set()
+    sf_len = len(DELAY_STATUS)
+    now = time.time()
+
+    for sf in workdir.glob(f"{DELAY_STATUS}*"):
+        try:
+            mtime = sf.stat().st_mtime
+        except FileNotFoundError:
+            continue
+
+        if now - mtime < valid_time_sec:
+            try:
+                instance_num = int(sf.name[sf_len:])
+                starting.add(instance_num)
+            except ValueError:
+                LOGGER.warning(f"Invalid status file name: {sf}")
+        else:
+            sf.unlink()
+
+    return starting
+
+
+def delay_instance(instance_num: int, workdir: pl.Path) -> bool:
+    """Delay the specified testnet instance to prevent concurrent access."""
+    lockfile = str(workdir / DELAY_LOCK)
+    with filelock.FileLock(lock_file=lockfile, timeout=2):
+        delay_instances = get_delay_instances(workdir=workdir)
+        if instance_num in delay_instances:
+            LOGGER.error(f"Instance number {instance_num} is already in use.")
+            return False
+        status_file = workdir / f"{DELAY_STATUS}{instance_num}"
+        status_file.touch()
+
+    return True

--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -184,6 +184,9 @@ def cmd_actions(
     if not ca_utils.has_supervisorctl():
         return 1
 
+    if not ca_utils.delay_instance(instance_num=instance_num, workdir=workdir_pl):
+        return 1
+
     if stop:
         kill_starting_testnet(pidfile=workdir_pl / f"start_cluster{instance_num}.pid")
         testnet_stop(statedir=statedir, env=env)
@@ -202,6 +205,8 @@ def cmd_stopall(workdir: str) -> int:
     """Stop all running testnet instances."""
     workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
     for i in ca_utils.get_running_instances(workdir=workdir_pl):
+        if not ca_utils.delay_instance(instance_num=i, workdir=workdir_pl):
+            continue
         kill_starting_testnet(pidfile=workdir_pl / f"start_cluster{i}.pid")
         statedir = workdir_pl / f"state-cluster{i}"
         env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=i)


### PR DESCRIPTION
Introduce a filelock-based mechanism to prevent concurrent access to testnet instances. Replace previous status file logic with a unified delay system using `delay_instance` and `get_delay_instances` in `ca_utils.py`. Update `cli_create.py` and `cli_control.py` to use the new delay logic, ensuring that instance allocation and actions are properly synchronized. Add `filelock` as a dependency in `pyproject.toml`.