### PR TITLE
chore(gitignore): add .nix_venv to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ target/
 
 # virtualenv
 .venv*
+.nix_venv
 venv/
 ENV/
 


### PR DESCRIPTION
Include .nix_venv in .gitignore to prevent accidental commits of virtual environments created by Nix-based workflows.