### PR TITLE
docs(readme): add pro tip for background and comment flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Starting the testnet cluster with `/var/tmp/cardonnay/cluster0_conway_fast/start
 Cluster started 🚀
 ```
 
+> ℹ️ **Pro Tip:** Add `-b` to create the testnet in the background, or `-c "comment"` to add a comment.
+
 ### 2. List running testnet instances
 
 `$ cardonnay control ls`


### PR DESCRIPTION
Added a "Pro Tip" section to the README highlighting the use of the `-b` flag to run the testnet in the background and the `-c "comment"` flag to add a comment when starting the testnet cluster. This improves usability by making advanced options more discoverable.