### PR TITLE
feat(inspect): add supervisord_pid to InstanceInfo

### DIFF
--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -176,12 +176,21 @@ def get_testnet_info(statedir: pl.Path) -> structs.InstanceInfo:
 
     workdir = statedir.parent
 
-    start_pid = -1
-    pidfile = workdir / f"start_cluster{instance_num}.pid"
-    if pidfile.exists() and testnet_state == consts.States.STARTING:
+    supervisord_pid = -1
+    supervisord_pidfile = statedir / "supervisord.pid"
+    if supervisord_pidfile.exists():
         pid = 0
         with contextlib.suppress(Exception):
-            pid = int(helpers.read_from_file(pidfile))
+            pid = int(helpers.read_from_file(supervisord_pidfile))
+        if pid:
+            supervisord_pid = pid
+
+    start_pid = -1
+    start_pidfile = workdir / f"start_cluster{instance_num}.pid"
+    if start_pidfile.exists() and testnet_state == consts.States.STARTING:
+        pid = 0
+        with contextlib.suppress(Exception):
+            pid = int(helpers.read_from_file(start_pidfile))
         if pid:
             start_pid = pid
 
@@ -197,6 +206,7 @@ def get_testnet_info(statedir: pl.Path) -> structs.InstanceInfo:
         dir=statedir,
         comment=testnet_info.get("comment"),
         submit_api_port=sp if (sp := get_submit_api_port(statedir=statedir)) > 0 else None,
+        supervisord_pid=supervisord_pid if supervisord_pid > 0 else None,
         start_pid=start_pid if start_pid > 0 else None,
         start_logfile=start_logfile,
         control_env=get_control_env(statedir=statedir),

--- a/src/cardonnay/structs.py
+++ b/src/cardonnay/structs.py
@@ -46,6 +46,7 @@ class InstanceInfo(pydantic.BaseModel):
     dir: pl.Path
     comment: str | None
     submit_api_port: int | None
+    supervisord_pid: int | None
     start_pid: int | None
     start_logfile: pl.Path | None
     control_env: dict[str, str]


### PR DESCRIPTION
Add logic in `get_testnet_info` to read the supervisord PID from the `supervisord.pid` file in the statedir, and include it in the returned InstanceInfo as the new `supervisord_pid` field. Update the InstanceInfo model to support this new optional field.