### PR TITLE
refactor: centralize state-cluster prefix usage

### DIFF
--- a/src/cardonnay/ca_utils.py
+++ b/src/cardonnay/ca_utils.py
@@ -16,10 +16,14 @@ TESTNET_JSON = "testnet.json"
 STATUS_STARTED = "status_started"
 DELAY_STATUS = "delay_stat"
 DELAY_LOCK = "delay.lock"
+STATE_CLUSTER_PREFIX = "state-cluster"
+STATE_CLUSTER_PREFIX_LEN = len("state-cluster")
 
 
 def create_env_vars(workdir: pl.Path, instance_num: int) -> dict[str, str]:
-    env = {"CARDANO_NODE_SOCKET_PATH": f"{workdir}/state-cluster{instance_num}/bft1.socket"}
+    env = {
+        "CARDANO_NODE_SOCKET_PATH": f"{workdir}/{STATE_CLUSTER_PREFIX}{instance_num}/bft1.socket"
+    }
     return env
 
 
@@ -37,8 +41,8 @@ def get_workdir(workdir: ttypes.FileType) -> pl.Path:
 
 def get_running_instances(workdir: pl.Path) -> set[int]:
     instances = {
-        int(s.parent.name.replace("state-cluster", ""))
-        for s in workdir.glob("state-cluster*/supervisord.sock")
+        int(s.parent.name[STATE_CLUSTER_PREFIX_LEN:])
+        for s in workdir.glob(f"{STATE_CLUSTER_PREFIX}*/supervisord.sock")
     }
     return instances
 

--- a/src/cardonnay/cli_control.py
+++ b/src/cardonnay/cli_control.py
@@ -100,7 +100,7 @@ def print_instances(workdir: pl.Path) -> None:
     out_list: list[structs.InstanceSummary] = []
 
     for i in running_instances:
-        statedir = workdir / f"state-cluster{i}"
+        statedir = workdir / f"{ca_utils.STATE_CLUSTER_PREFIX}{i}"
 
         with (
             contextlib.suppress(Exception),
@@ -174,7 +174,7 @@ def cmd_actions(
         LOGGER.error("Valid instance number is required.")
         return 1
 
-    statedir = workdir_pl / f"state-cluster{instance_num}"
+    statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
     env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=instance_num)
 
     if instance_num not in ca_utils.get_running_instances(workdir=workdir_pl):
@@ -211,7 +211,7 @@ def cmd_stopall(workdir: str) -> int:
             run_retval = 1
             continue
         kill_starting_testnet(pidfile=workdir_pl / f"start_cluster{i}.pid")
-        statedir = workdir_pl / f"state-cluster{i}"
+        statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{i}"
         env = ca_utils.create_env_vars(workdir=workdir_pl, instance_num=i)
         stop_retval = testnet_stop(statedir=statedir, env=env)
         run_retval = stop_retval if stop_retval != 0 else run_retval

--- a/src/cardonnay/cli_create.py
+++ b/src/cardonnay/cli_create.py
@@ -55,7 +55,7 @@ def print_available_testnets(scripts_base: pl.Path, verbose: bool) -> int:
 
 def get_start_info(statedir: pl.Path, testnet_variant: str) -> structs.StartInfo:
     """Get information about the starting testnet instance."""
-    instance_num = int(statedir.name.replace("state-cluster", ""))
+    instance_num = int(statedir.name[ca_utils.STATE_CLUSTER_PREFIX_LEN :])
     workdir = statedir.parent
 
     start_pid = -1
@@ -114,7 +114,7 @@ def testnet_start(
         pidfile.unlink(missing_ok=True)
         pidfile.write_text(str(start_process.pid))
 
-        statedir = workdir / f"state-cluster{instance_num}"
+        statedir = workdir / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
         helpers.print_json(get_start_info(statedir=statedir, testnet_variant=testnet_variant))
     else:
         print(

--- a/src/cardonnay/cli_inspect.py
+++ b/src/cardonnay/cli_inspect.py
@@ -25,7 +25,7 @@ def check_prereq(
 
 def cmd_faucet(workdir: str, instance_num: int) -> int:
     workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
-    statedir = workdir_pl / f"state-cluster{instance_num}"
+    statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -36,7 +36,7 @@ def cmd_faucet(workdir: str, instance_num: int) -> int:
 
 def cmd_pools(workdir: str, instance_num: int) -> int:
     workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
-    statedir = workdir_pl / f"state-cluster{instance_num}"
+    statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -50,7 +50,7 @@ def cmd_pools(workdir: str, instance_num: int) -> int:
 
 def cmd_status(workdir: str, instance_num: int) -> int:
     workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
-    statedir = workdir_pl / f"state-cluster{instance_num}"
+    statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret
@@ -61,7 +61,7 @@ def cmd_status(workdir: str, instance_num: int) -> int:
 
 def cmd_config(workdir: str, instance_num: int) -> int:
     workdir_pl = ca_utils.get_workdir(workdir=workdir).absolute()
-    statedir = workdir_pl / f"state-cluster{instance_num}"
+    statedir = workdir_pl / f"{ca_utils.STATE_CLUSTER_PREFIX}{instance_num}"
 
     if (ret := check_prereq(statedir=statedir, instance_num=instance_num)) > 0:
         return ret

--- a/src/cardonnay/inspect_instance.py
+++ b/src/cardonnay/inspect_instance.py
@@ -172,7 +172,7 @@ def get_testnet_info(statedir: pl.Path) -> structs.InstanceInfo:
         testnet_info = {}
 
     testnet_name = testnet_info.get("name") or "unknown"
-    instance_num = int(statedir.name.replace("state-cluster", ""))
+    instance_num = int(statedir.name[ca_utils.STATE_CLUSTER_PREFIX_LEN :])
 
     workdir = statedir.parent
 


### PR DESCRIPTION
Move the "state-cluster" prefix and its length to constants in ca_utils.py. Update all usages across modules to reference these constants, improving maintainability and reducing duplication. This change ensures consistent handling of instance directory naming and parsing throughout the codebase.