### PR TITLE
docs(readme): add testnet usage example and clarify steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ Cluster started 🚀
 }
 ```
 
-### 4. Stop all running testnet instances
+### 4. Work with the testnet
+
+```sh
+source <(cardonnay control print-env -i 0)
+cardano-cli query tip --testnet-magic 42
+```
+
+### 5. Stop all running testnet instances
 
 ```sh
 $ cardonnay control stop-all


### PR DESCRIPTION
Expanded the testnet section in the README to include an example of sourcing the environment and querying the tip using cardano-cli.