### PR TITLE
chore: update linting tools and fix struct inheritance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,21 @@ repos:
     language_version: python3
   - id: debug-statements
     language_version: python3
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.11.12
+- repo: local
   hooks:
-    - id: ruff
+  - id: pyrefly
+    name: pyrefly
+    entry: pyrefly
+    # pyrefly is stupid and adds 'src' to 'project-excludes',
+    # so it must be added here
+    args: [ check, --remove-unused-ignores, src ]
+    pass_filenames: false
+    language: system
+    types: [python]
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.12.1
+  hooks:
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format
 - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -28,13 +39,6 @@ repos:
   - id: markdownlint
 - repo: local
   hooks:
-  - id: pyrefly
-    name: pyrefly
-    entry: pyrefly
-    args: [ check, --remove-unused-ignores ]
-    pass_filenames: false
-    language: system
-    types: [python]
   - id: mypy
     name: mypy
     entry: mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -e .
 
 # linting
-mypy~=1.15.0
-pyrefly~=0.17.0
+mypy~=1.16.1
+pyrefly~=0.22.0
 pre-commit~=4.2.0
-ipython~=8.29.0
+ipython~=9.3.0
 
 build

--- a/src/cardonnay/structs.py
+++ b/src/cardonnay/structs.py
@@ -8,7 +8,9 @@ class KeyPair(pydantic.BaseModel):
     skey_file: pl.Path
 
 
-class ColdKeyPair(KeyPair):
+class ColdKeyPair(pydantic.BaseModel):
+    vkey_file: pl.Path
+    skey_file: pl.Path
     counter_file: pl.Path
 
 

--- a/src/cardonnay_scripts/__init__.py
+++ b/src/cardonnay_scripts/__init__.py
@@ -1,4 +1,3 @@
 from importlib import resources
 
-# pyrefly: ignore  # unknown-name
 SCRIPTS_ROOT = resources.files(__package__) / "scripts"


### PR DESCRIPTION
- Bump mypy, pyrefly, and ipython versions in requirements-dev.txt.
- Update pre-commit config:
  - Use latest ruff and pyrefly hooks.
  - Move pyrefly check before ruff format, as pyrefly can modify the code.
- Fix ColdKeyPair to inherit from BaseModel directly, not KeyPair.
- Remove unnecessary pyrefly ignore comment in __init__.py.