### PR TITLE
fix(pyproject): update license field to SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Cardano Local Testnet"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["cardano", "cardano-node", "cardano-cli"]
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Changed the license field in pyproject.toml from a text object to the SPDX identifier "Apache-2.0" for better compatibility with packaging tools and repositories.