### PR TITLE
fix(pre-commit): clarify pyrefly limitation in config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: pyrefly
     name: pyrefly
     entry: pyrefly
-    # pyrefly is stupid and adds 'src' to 'project-excludes',
+    # pyrefly doesn't handle editable installs and adds 'src' to 'project-excludes',
     # so it must be added here
     args: [ check, --remove-unused-ignores, src ]
     pass_filenames: false


### PR DESCRIPTION
Update the comment in .pre-commit-config.yaml to clarify that pyrefly does not handle editable installs and adds 'src' to 'project-excludes'. This provides better context for the workaround in the args section.