### PR TITLE
fix(cluster): remove stale supervisord socket on stop failure

### DIFF
--- a/src/cardonnay_scripts/scripts/common/start-cluster
+++ b/src/cardonnay_scripts/scripts/common/start-cluster
@@ -545,7 +545,7 @@ PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
 if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
-  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all || rm -f "\$SUPERVISORD_SOCKET_PATH"
 fi
 
 if [ ! -f "\$PID_FILE" ]; then

--- a/src/cardonnay_scripts/scripts/common/stop-cluster
+++ b/src/cardonnay_scripts/scripts/common/stop-cluster
@@ -19,7 +19,7 @@ if [[ "$SOCKET_PATH" != *"/state-cluster${INSTANCE_NUM}/"* ]]; then
 fi
 
 if [ -e "$SUPERVISORD_SOCKET_PATH" ]; then
-  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" stop all || rm -f "$SUPERVISORD_SOCKET_PATH"
 fi
 
 if [ ! -f "$PID_FILE" ]; then

--- a/src/cardonnay_scripts/scripts/conway_slow/start-cluster
+++ b/src/cardonnay_scripts/scripts/conway_slow/start-cluster
@@ -627,7 +627,7 @@ PID_FILE="\${SCRIPT_DIR}/supervisord.pid"
 SUPERVISORD_SOCKET_PATH="${SUPERVISORD_SOCKET_PATH}"
 
 if [ -e "\$SUPERVISORD_SOCKET_PATH" ]; then
-  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all
+  supervisorctl -s unix:///\${SUPERVISORD_SOCKET_PATH} stop all || rm -f "\$SUPERVISORD_SOCKET_PATH"
 fi
 
 if [ ! -f "\$PID_FILE" ]; then


### PR DESCRIPTION
If supervisorctl fails to stop all processes, remove the supervisord socket file to prevent issues on subsequent cluster starts. This change applies to common and conway_slow cluster scripts.