### PR TITLE
fix(start-cluster): handle state dir deletion errors

### DIFF
--- a/src/cardonnay_scripts/scripts/common/start-cluster
+++ b/src/cardonnay_scripts/scripts/common/start-cluster
@@ -11,6 +11,11 @@ fi
 SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
+# Fail if PWD is STATE_CLUSTER, as STATE_CLUSTER will be deleted
+if [ "$PWD" = "$STATE_CLUSTER" ]; then
+  echo "Please run this script from outside of '$STATE_CLUSTER'" >&2
+  exit 1
+fi
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
@@ -69,7 +74,10 @@ if [ -e "${SCRIPT_DIR}/shell_env" ]; then
   source "${SCRIPT_DIR}/shell_env"
 fi
 
-rm -rf "$STATE_CLUSTER"
+if ! ( rm -rf "$STATE_CLUSTER" || rm -rf "$STATE_CLUSTER"; ); then
+  echo "Could not remove existing '$STATE_CLUSTER'" >&2
+  exit 1
+fi
 mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,create_staked,governance_data}
 cd "${STATE_CLUSTER}/.."
 

--- a/src/cardonnay_scripts/scripts/conway_slow/start-cluster
+++ b/src/cardonnay_scripts/scripts/conway_slow/start-cluster
@@ -11,6 +11,11 @@ fi
 SCRIPT_DIR="$(readlink -m "${0%/*}")"
 SOCKET_PATH="$(readlink -m "$CARDANO_NODE_SOCKET_PATH")"
 STATE_CLUSTER="${SOCKET_PATH%/*}"
+# Fail if PWD is STATE_CLUSTER, as STATE_CLUSTER will be deleted
+if [ "$PWD" = "$STATE_CLUSTER" ]; then
+  echo "Please run this script from outside of '$STATE_CLUSTER'" >&2
+  exit 1
+fi
 STATE_CLUSTER_NAME="${STATE_CLUSTER##*/}"
 SUPERVISORD_SOCKET_PATH="${STATE_CLUSTER}/supervisord.sock"
 # shellcheck disable=SC2034
@@ -67,7 +72,10 @@ if [ -e "${SCRIPT_DIR}/shell_env" ]; then
   source "${SCRIPT_DIR}/shell_env"
 fi
 
-rm -rf "$STATE_CLUSTER"
+if ! ( rm -rf "$STATE_CLUSTER" || rm -rf "$STATE_CLUSTER"; ); then
+  echo "Could not remove existing '$STATE_CLUSTER'" >&2
+  exit 1
+fi
 mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,governance_data}
 cd "${STATE_CLUSTER}/.."
 


### PR DESCRIPTION
Add a check to ensure the script is not run from inside the state directory, which will be deleted. Improve error handling when removing the state directory by reporting failures and exiting if removal fails.