### PR TITLE
feat(scripts): enforce required env vars and switch to C-style for loops

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -250,7 +250,7 @@ edit_node_configs() {
 create_bft_nodes_files() {
   local i bft_port
 
-  for i in $(seq 1 "$NUM_BFT_NODES"); do
+  for ((i=1; i<="${NUM_BFT_NODES:?}"; i++)); do
     mkdir -p "${STATE_CLUSTER}/nodes/node-bft$i"
     bft_port="$((NODE_PORT_BASE + (i - 1) * PORTS_PER_NODE ))"
     echo "$bft_port" > "${STATE_CLUSTER}/nodes/node-bft${i}/port"
@@ -343,7 +343,7 @@ _create_pool_registration() {
 
 create_pools_files() {
   local i
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     _create_pool_node_keys "$i"
     create_pool_metadata "$i"
     _create_pool_registration "$i"
@@ -383,7 +383,7 @@ register_entities_in_conway() {
   local -a pool_args=()
   local -a pool_signing=()
   local i
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     pool_args+=( \
       "--tx-out" "$(<"${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr")+${POOL_PLEDGE}" \
       "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.cert" \
@@ -413,7 +413,7 @@ register_entities_in_conway() {
 
   local -a dreps_args=()
   local -a dreps_signing=()
-  for i in $(seq 1 "$NUM_DREPS"); do
+  for ((i=1; i<="${NUM_DREPS:?}"; i++)); do
     dreps_args+=( \
       "--tx-out" "$(<"${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr")+${DREP_DELEGATED}" \
       "--certificate-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert" \

--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -229,7 +229,7 @@ edit_node_configs() {
 create_bft_nodes_files() {
   local i index bft_port
 
-  for i in $(seq 1 "$NUM_BFT_NODES"); do
+  for ((i=1; i<="${NUM_BFT_NODES:?}"; i++)); do
     mkdir -p "${STATE_CLUSTER}/nodes/node-bft$i"
     ln -s "../../shelley/delegate-keys/delegate${i}.vrf.skey" "${STATE_CLUSTER}/nodes/node-bft${i}/vrf.skey"
     ln -s "../../shelley/delegate-keys/delegate${i}.vrf.vkey" "${STATE_CLUSTER}/nodes/node-bft${i}/vrf.vkey"
@@ -409,7 +409,7 @@ _create_pool_registration() {
 
 create_pools_files() {
   local i
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     _create_pool_node_keys "$i"
     create_pool_metadata "$i"
     _create_pool_registration "$i"
@@ -461,7 +461,7 @@ submit_byron_proposal_with_votes() {
     --filepath "$proposal_file"
   sleep 5
 
-  for i in $(seq 1 "$NUM_BFT_NODES"); do
+  for ((i=1; i<="${NUM_BFT_NODES:?}"; i++)); do
     cardano_cli_log byron governance create-proposal-vote \
       --proposal-filepath "$proposal_file" \
       --testnet-magic "$NETWORK_MAGIC" \
@@ -595,7 +595,7 @@ _register_governance_in_conway() {
 
   local -a dreps_args=()
   local -a dreps_signing=()
-  for i in $(seq 1 "$NUM_DREPS"); do
+  for ((i=1; i<="${NUM_DREPS:?}"; i++)); do
     dreps_args+=( \
       "--tx-out" "$(<"${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr")+${DREP_DELEGATED}" \
       "--certificate-file" "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert" \
@@ -611,7 +611,7 @@ _register_governance_in_conway() {
 
   local -a pool_args=()
   local -a pool_signing=()
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     pool_args+=( \
       "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake-reward.vote_deleg.cert" \
     )
@@ -876,7 +876,7 @@ submit_byron_genesis_txs() {
 
   echo "Moving funds out of Byron genesis"
   local i
-  for i in $(seq 1 "$NUM_BFT_NODES"); do
+  for ((i=1; i<="${NUM_BFT_NODES:?}"; i++)); do
     cardano_cli_log byron transaction submit-tx \
       --testnet-magic "$NETWORK_MAGIC" \
       --tx "${STATE_CLUSTER}/byron/tx${i}.tx"
@@ -944,7 +944,7 @@ hf_to_allegra() {
   local -a pool_args=()
   local -a pool_signing=()
   local i
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     pool_args+=( \
       "--tx-out" "$(<"${STATE_CLUSTER}/nodes/node-pool${i}/owner.addr")+${POOL_PLEDGE}" \
       "--certificate-file" "${STATE_CLUSTER}/nodes/node-pool${i}/stake.reg.shelley.cert" \

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -16,21 +16,21 @@ is_truthy() {
 
 get_epoch_sec() {
   if [ -z "${EPOCH_SEC:-}" ]; then
-    EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "${STATE_CLUSTER}/shelley/genesis.json")"
+    EPOCH_SEC="$(jq '.epochLength * .slotLength | ceil' < "${STATE_CLUSTER:?}/shelley/genesis.json")"
   fi
   echo "$EPOCH_SEC"
 }
 
 get_slot_length() {
   if [ -z "${SLOT_LENGTH:-}" ]; then
-    SLOT_LENGTH="$(jq '.slotLength' < "${STATE_CLUSTER}/shelley/genesis.json")"
+    SLOT_LENGTH="$(jq '.slotLength' < "${STATE_CLUSTER:?}/shelley/genesis.json")"
   fi
   echo "$SLOT_LENGTH"
 }
 
 cardano_cli_log() {
   if [ -z "${START_CLUSTER_LOG:-}" ]; then
-    START_CLUSTER_LOG="${STATE_CLUSTER}/start-cluster.log"
+    START_CLUSTER_LOG="${STATE_CLUSTER:?}/start-cluster.log"
   fi
 
   echo cardano-cli "$@" >> "$START_CLUSTER_LOG"
@@ -42,7 +42,7 @@ check_spend_success() {
   local _
   for _ in {1..10}; do
     if ! cardano_cli_log latest query utxo "$@" \
-      --testnet-magic "$NETWORK_MAGIC" --output-text | grep -q lovelace; then
+      --testnet-magic "${NETWORK_MAGIC:?}" --output-text | grep -q lovelace; then
       return 0
     fi
     sleep 3
@@ -72,7 +72,7 @@ get_txins() {
         break
       fi
     done <<< "$(cardano_cli_log latest query utxo \
-                --testnet-magic "$NETWORK_MAGIC" \
+                --testnet-magic "${NETWORK_MAGIC:?}" \
                 --output-text \
                 --address "$txin_addr" |
                 grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$" || echo "")"
@@ -95,7 +95,7 @@ get_address_balance() {
       fi
       total_amount="$((total_amount + amount))"
     done <<< "$(cardano-cli latest query utxo \
-                --testnet-magic "$NETWORK_MAGIC" \
+                --testnet-magic "${NETWORK_MAGIC:?}" \
                 --output-text \
                 "$@" |
                 grep " lovelace" || echo "")"
@@ -109,20 +109,20 @@ get_address_balance() {
 }
 
 get_epoch() {
-  cardano_cli_log latest query tip --testnet-magic "$NETWORK_MAGIC" | jq -r '.epoch'
+  cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" | jq -r '.epoch'
 }
 
 get_slot() {
   local future_offset="${1:-0}"
-  cardano_cli_log latest query tip --testnet-magic "$NETWORK_MAGIC" | jq -r ".slot + $future_offset"
+  cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" | jq -r ".slot + $future_offset"
 }
 
 get_era() {
-  cardano_cli_log latest query tip --testnet-magic "$NETWORK_MAGIC" | jq -r '.era'
+  cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" | jq -r '.era'
 }
 
 get_sec_to_epoch_end() {
-  cardano_cli_log latest query tip --testnet-magic "$NETWORK_MAGIC" |
+  cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" |
     jq -r "$(get_slot_length) * .slotsToEpochEnd | ceil"
 }
 
@@ -200,7 +200,7 @@ save_protocol_params() {
   local era="${2:-latest}"
 
   cardano_cli_log "$era" query protocol-parameters \
-    --testnet-magic "$NETWORK_MAGIC" \
+    --testnet-magic "${NETWORK_MAGIC:?}" \
     --out-file "$pparams_file"
 }
 
@@ -214,10 +214,10 @@ configure_supervisor() {
 
   local -a node_names=()
   local i
-  for i in $(seq 1 "${NUM_BFT_NODES:?}"); do
+  for ((i=1; i<="${NUM_BFT_NODES:?}"; i++)); do
     node_names+=("bft${i}")
   done
-  for i in $(seq 1 "${NUM_POOLS:?}"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     node_names+=("pool${i}")
   done
 
@@ -282,7 +282,7 @@ EoF
   fi
 
   if command -v cardano-submit-api >/dev/null 2>&1; then
-    cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+    cat >> "${STATE_CLUSTER:?}/supervisor.conf" <<EoF
 
 [program:submit_api]
 command=./${STATE_CLUSTER_NAME:?}/run-cardano-submit-api
@@ -295,7 +295,7 @@ EoF
   fi
 
   if is_truthy "${ENABLE_TX_GENERATOR:-}"; then
-    cp "${SCRIPT_DIR:?}/run-tx-generator" "$STATE_CLUSTER"
+    cp "${SCRIPT_DIR:?}/run-tx-generator" "${STATE_CLUSTER:?}"
 
     cat >> "${STATE_CLUSTER:?}/supervisor.conf" <<EoF
 
@@ -329,10 +329,10 @@ EoF
 
 create_cluster_scripts() {
   printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s start all" "${SUPERVISORD_SOCKET_PATH:?}" > "${STATE_CLUSTER:?}/supervisorctl_start"
-  printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s restart nodes:" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_restart_nodes"
-  printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "$SUPERVISORD_SOCKET_PATH" > "${STATE_CLUSTER}/supervisorctl_local"
+  printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s restart nodes:" "${SUPERVISORD_SOCKET_PATH:?}" > "${STATE_CLUSTER:?}/supervisorctl_restart_nodes"
+  printf "#!/bin/sh\n\nsupervisorctl -s unix:///%s \"\$@\"" "${SUPERVISORD_SOCKET_PATH:?}" > "${STATE_CLUSTER:?}/supervisorctl_local"
 
-  cat > "${STATE_CLUSTER}/supervisord_start" <<'EoF'
+  cat > "${STATE_CLUSTER:?}/supervisord_start" <<'EoF'
 #!/usr/bin/env bash
 
 set -uo pipefail
@@ -344,7 +344,7 @@ cd "${SCRIPT_DIR}/.."
 supervisord --config "${SCRIPT_DIR}/supervisor.conf"
 EoF
 
-  cat > "${STATE_CLUSTER}/stop-cluster" <<EoF
+  cat > "${STATE_CLUSTER:?}/stop-cluster" <<EoF
 #!/usr/bin/env bash
 
 set -uo pipefail
@@ -377,7 +377,7 @@ rm -f "\$PID_FILE"
 echo "Cluster terminated!"
 EoF
 
-  chmod u+x "$STATE_CLUSTER"/{supervisorctl*,supervisord_*,stop-cluster}
+  chmod u+x "${STATE_CLUSTER:?}"/{supervisorctl*,supervisord_*,stop-cluster}
 }
 
 start_cluster_nodes() {
@@ -396,7 +396,7 @@ start_cluster_nodes() {
     echo "Waiting 5 seconds for the nodes to start"
     sleep 5
   done
-  [ -S "$CARDANO_NODE_SOCKET_PATH" ] || { echo "Failed to start the nodes, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+  [ -S "${CARDANO_NODE_SOCKET_PATH:?}" ] || { echo "Failed to start the nodes, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
 }
 
 start_optional_services() {
@@ -422,7 +422,7 @@ create_pool_metadata() {
   local pool_desc="Test Pool $pool_ix"
   local pool_ticker="TP${pool_ix}"
 
-  cat > "${STATE_CLUSTER}/webserver/pool${pool_ix}.html" <<EoF
+  cat > "${STATE_CLUSTER:?}/webserver/pool${pool_ix}.html" <<EoF
 <!DOCTYPE html>
 <html>
 <head>
@@ -453,62 +453,62 @@ setup_state_cluster() {
     echo "Could not remove existing '$STATE_CLUSTER'" >&2
     exit 1
   fi
-  mkdir -p "$STATE_CLUSTER"/{shelley,webserver,db-sync,governance_data}
-  cd "${STATE_CLUSTER}/.." || { echo "Could not cd to '${STATE_CLUSTER}/..', line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+  mkdir -p "${STATE_CLUSTER:?}"/{shelley,webserver,db-sync,governance_data}
+  cd "${STATE_CLUSTER:?}/.." || { echo "Could not cd to '${STATE_CLUSTER}/..', line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
 
   mkdir -p "$genesis_init_dir"
 
-  cp "${SCRIPT_DIR:?}"/cardano-node-* "$STATE_CLUSTER"
-  cp "${SCRIPT_DIR}/run-cardano-submit-api" "$STATE_CLUSTER"
-  cp "${SCRIPT_DIR}/byron-params.json" "$STATE_CLUSTER"
-  cp "${SCRIPT_DIR}/dbsync-config.yaml" "$STATE_CLUSTER"
-  cp "${SCRIPT_DIR}/submit-api-config.json" "$STATE_CLUSTER"
-  cp "$SCRIPT_DIR/testnet.json" "$STATE_CLUSTER"
-  cp "$SCRIPT_DIR"/*genesis*.spec.json "$genesis_init_dir"
-  cp "$SCRIPT_DIR"/cost_models*.json "$genesis_init_dir" 2>/dev/null || true
-  cp "$SCRIPT_DIR"/topology-*.json "$STATE_CLUSTER"
+  cp "${SCRIPT_DIR:?}"/cardano-node-* "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}/run-cardano-submit-api" "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}/byron-params.json" "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}/dbsync-config.yaml" "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}/submit-api-config.json" "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}/testnet.json" "${STATE_CLUSTER:?}"
+  cp "${SCRIPT_DIR:?}"/*genesis*.spec.json "$genesis_init_dir"
+  cp "${SCRIPT_DIR:?}"/cost_models*.json "$genesis_init_dir" 2>/dev/null || true
+  cp "${SCRIPT_DIR:?}"/topology-*.json "${STATE_CLUSTER:?}"
 }
 
 create_dreps_files() {
   local i
-  for i in $(seq 1 "$NUM_DREPS"); do
+  for ((i=1; i<="${NUM_DREPS:?}"; i++)); do
     cardano_cli_log conway governance drep key-gen \
-      --signing-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.skey" \
-      --verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey"
+      --signing-key-file "${STATE_CLUSTER:?}/governance_data/default_drep_${i}_drep.skey" \
+      --verification-key-file "${STATE_CLUSTER:?}/governance_data/default_drep_${i}_drep.vkey"
 
     cardano_cli_log conway governance drep registration-certificate \
-      --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
-      --key-reg-deposit-amt "$DREP_DEPOSIT" \
-      --out-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep_reg.cert"
+      --drep-verification-key-file "${STATE_CLUSTER:?}/governance_data/default_drep_${i}_drep.vkey" \
+      --key-reg-deposit-amt "${DREP_DEPOSIT:?}" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/default_drep_${i}_drep_reg.cert"
 
     cardano_cli_log conway address key-gen \
-      --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.skey" \
-      --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey"
+      --signing-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}.skey" \
+      --verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}.vkey"
 
     cardano_cli_log conway stake-address key-gen \
-      --signing-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.skey" \
-      --verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey"
+      --signing-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.skey" \
+      --verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vkey"
 
     cardano_cli_log conway address build \
-      --payment-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.vkey" \
-      --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
-      --testnet-magic "$NETWORK_MAGIC" \
-      --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}.addr"
+      --payment-verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}.vkey" \
+      --stake-verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vkey" \
+      --testnet-magic "${NETWORK_MAGIC:?}" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}.addr"
 
     cardano_cli_log conway stake-address build \
-      --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
-      --testnet-magic "$NETWORK_MAGIC" \
-      --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.addr"
+      --stake-verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vkey" \
+      --testnet-magic "${NETWORK_MAGIC:?}" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.addr"
 
     cardano_cli_log conway stake-address registration-certificate \
-      --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
-      --key-reg-deposit-amt "$KEY_DEPOSIT" \
-      --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.reg.cert"
+      --stake-verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vkey" \
+      --key-reg-deposit-amt "${KEY_DEPOSIT:?}" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.reg.cert"
 
     cardano_cli_log conway stake-address vote-delegation-certificate \
-      --stake-verification-key-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vkey" \
-      --drep-verification-key-file "${STATE_CLUSTER}/governance_data/default_drep_${i}_drep.vkey" \
-      --out-file "${STATE_CLUSTER}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
+      --stake-verification-key-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vkey" \
+      --drep-verification-key-file "${STATE_CLUSTER:?}/governance_data/default_drep_${i}_drep.vkey" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/vote_stake_addr${i}_stake.vote_deleg.cert"
   done
 }
 
@@ -518,44 +518,44 @@ create_committee_keys_in_genesis() {
   fi
 
   local i
-  for i in $(seq 1 "${NUM_CC:?}"); do
+  for ((i=1; i<="${NUM_CC:?}"; i++)); do
     cardano_cli_log conway governance committee key-gen-cold \
       --cold-verification-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_cold.vkey" \
-      --cold-signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.skey"
+      --cold-signing-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_cold.skey"
     cardano_cli_log conway governance committee key-gen-hot \
-      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
-      --signing-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.skey"
+      --verification-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --signing-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_hot.skey"
     cardano_cli_log conway governance committee create-hot-key-authorization-certificate \
-      --cold-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
-      --hot-verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot.vkey" \
-      --out-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_hot_auth.cert"
+      --cold-verification-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_cold.vkey" \
+      --hot-verification-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_hot.vkey" \
+      --out-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_hot_auth.cert"
     cardano_cli_log conway governance committee key-hash \
-      --verification-key-file "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.vkey" \
-      > "${STATE_CLUSTER}/governance_data/cc_member${i}_committee_cold.hash"
+      --verification-key-file "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_cold.vkey" \
+      > "${STATE_CLUSTER:?}/governance_data/cc_member${i}_committee_cold.hash"
   done
 
   local key_hash_json
   key_hash_json="$(jq -nR '[inputs | {("keyHash-" + .): 10000}] | add' \
-    "$STATE_CLUSTER"/governance_data/cc_member*_committee_cold.hash)"
+    "${STATE_CLUSTER:?}"/governance_data/cc_member*_committee_cold.hash)"
   jq \
     --argjson keyHashJson "$key_hash_json" '
     .committee.members = $keyHashJson
     | .committee.threshold = 0.6
     | .committeeMinSize = 2
     | .plutusV3CostModel |= .[0:251]
-    ' "${STATE_CLUSTER}/shelley/genesis.conway.json" > "${STATE_CLUSTER}/shelley/genesis.conway.tmp.json"
-  mv -f "${STATE_CLUSTER}/shelley/genesis.conway.tmp.json" "${STATE_CLUSTER}/shelley/genesis.conway.json"
+    ' "${STATE_CLUSTER:?}/shelley/genesis.conway.json" > "${STATE_CLUSTER:?}/shelley/genesis.conway.tmp.json"
+  mv -f "${STATE_CLUSTER:?}/shelley/genesis.conway.tmp.json" "${STATE_CLUSTER:?}/shelley/genesis.conway.json"
 }
 
 edit_genesis_conf() {
   local conf="${1:?"Missing node config file"}"
 
   jq \
-    --arg byron_hash "$BYRON_GENESIS_HASH" \
-    --arg shelley_hash "$SHELLEY_GENESIS_HASH" \
-    --arg alonzo_hash "$ALONZO_GENESIS_HASH" \
-    --arg conway_hash "$CONWAY_GENESIS_HASH" \
-    --arg dijkstra_hash "$DIJKSTRA_GENESIS_HASH" '
+    --arg byron_hash "${BYRON_GENESIS_HASH:?}" \
+    --arg shelley_hash "${SHELLEY_GENESIS_HASH:?}" \
+    --arg alonzo_hash "${ALONZO_GENESIS_HASH:?}" \
+    --arg conway_hash "${CONWAY_GENESIS_HASH:?}" \
+    --arg dijkstra_hash "${DIJKSTRA_GENESIS_HASH:-}" '
     .ByronGenesisHash = $byron_hash
     | .ShelleyGenesisHash = $shelley_hash
     | .AlonzoGenesisHash = $alonzo_hash
@@ -619,27 +619,27 @@ use_genesis_mode() {
   echo "Setting up GenesisMode for pools, restarting nodes"
 
   cardano_cli_log query ledger-peer-snapshot \
-    --testnet-magic "$NETWORK_MAGIC" \
-    --socket-path "${STATE_CLUSTER}/pool1.socket" \
+    --testnet-magic "${NETWORK_MAGIC:?}" \
+    --socket-path "${STATE_CLUSTER:?}/pool1.socket" \
     --output-json \
-    --out-file "${STATE_CLUSTER}/peer-snapshot.json"
-  [ -e "${STATE_CLUSTER}/peer-snapshot.json" ] || \
+    --out-file "${STATE_CLUSTER:?}/peer-snapshot.json"
+  [ -e "${STATE_CLUSTER:?}/peer-snapshot.json" ] || \
     { echo "Failed to get peer snapshot from pool1, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
 
   local i
-  for i in $(seq 1 "$NUM_POOLS"); do
+  for ((i=1; i<="${NUM_POOLS:?}"; i++)); do
     jq '
       .localRoots[] += {"trustable": true}
       | .peerSnapshotFile = "peer-snapshot.json"
-      ' "${STATE_CLUSTER}/topology-pool${i}.json" > "${STATE_CLUSTER}/topology-pool${i}.tmp.json"
-    mv -f "${STATE_CLUSTER}/topology-pool${i}.tmp.json" "${STATE_CLUSTER}/topology-pool${i}.json"
+      ' "${STATE_CLUSTER:?}/topology-pool${i}.json" > "${STATE_CLUSTER:?}/topology-pool${i}.tmp.json"
+    mv -f "${STATE_CLUSTER:?}/topology-pool${i}.tmp.json" "${STATE_CLUSTER:?}/topology-pool${i}.json"
 
     jq '.ConsensusMode = "GenesisMode"' \
-      "${STATE_CLUSTER}/config-pool${i}.json" > "${STATE_CLUSTER}/config-pool${i}.tmp.json"
-    mv -f "${STATE_CLUSTER}/config-pool${i}.tmp.json" "${STATE_CLUSTER}/config-pool${i}.json"
+      "${STATE_CLUSTER:?}/config-pool${i}.json" > "${STATE_CLUSTER:?}/config-pool${i}.tmp.json"
+    mv -f "${STATE_CLUSTER:?}/config-pool${i}.tmp.json" "${STATE_CLUSTER:?}/config-pool${i}.json"
   done
 
-  supervisorctl -s unix:///"$SUPERVISORD_SOCKET_PATH" restart nodes:
+  supervisorctl -s unix:///"${SUPERVISORD_SOCKET_PATH:?}" restart nodes:
 }
 
 _fund_tx_generator() {
@@ -647,7 +647,7 @@ _fund_tx_generator() {
   local fund_amount="${2:?}"
   local fee=500000
   local stop_txin_amount="$((fund_amount + fee))"
-  local tx_base="${STATE_CLUSTER}/shelley/fund-tx-generator"
+  local tx_base="${STATE_CLUSTER:?}/shelley/fund-tx-generator"
   local addr_balance
 
   addr_balance="$(get_address_balance --address "$addr")"
@@ -656,7 +656,7 @@ _fund_tx_generator() {
     return
   fi
 
-  get_txins "$FAUCET_ADDR" "$stop_txin_amount"
+  get_txins "${FAUCET_ADDR:?}" "$stop_txin_amount"
 
   local txout_amount="$((TXIN_AMOUNT - stop_txin_amount))"
 
@@ -668,16 +668,16 @@ _fund_tx_generator() {
     --out-file "${tx_base}-tx.txbody"
 
   cardano_cli_log conway transaction sign \
-    --signing-key-file "$FAUCET_SKEY" \
-    --testnet-magic    "$NETWORK_MAGIC" \
+    --signing-key-file "${FAUCET_SKEY:?}" \
+    --testnet-magic    "${NETWORK_MAGIC:?}" \
     --tx-body-file     "${tx_base}-tx.txbody" \
     --out-file         "${tx_base}-tx.tx"
 
   cardano_cli_log conway transaction submit \
     --tx-file "${tx_base}-tx.tx" \
-    --testnet-magic "$NETWORK_MAGIC"
+    --testnet-magic "${NETWORK_MAGIC:?}"
 
-  sleep "$SUBMIT_DELAY"
+  sleep "${SUBMIT_DELAY:?}"
   if ! check_spend_success "${TXINS[@]}"; then
     echo "Failed to spend Tx inputs, line $LINENO in ${BASH_SOURCE[0]}" >&2
     exit 1
@@ -738,13 +738,13 @@ setup_tx_generator() {
   fi
 
   local fund_amount="${1:?}"
-  _fund_tx_generator "$(<"${STATE_CLUSTER}/shelley/genesis-utxo2.addr")" "$fund_amount"
+  _fund_tx_generator "$(<"${STATE_CLUSTER:?}/shelley/genesis-utxo2.addr")" "$fund_amount"
 
   _gen_tx_generator_config \
-    "${STATE_CLUSTER}/topology-bft1.json" \
+    "${STATE_CLUSTER:?}/topology-bft1.json" \
     "./pool1.socket" \
     "./config-pool1.json" \
-    "./shelley/genesis-utxo2.skey" > "${STATE_CLUSTER}/tx-generator-config.json"
+    "./shelley/genesis-utxo2.skey" > "${STATE_CLUSTER:?}/tx-generator-config.json"
 
   echo "Starting tx-generator"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH:?}" start tx_generator


### PR DESCRIPTION
- Replace `seq`-based for loops with C-style for loops using `${VAR:?}` to ensure required environment variables are set, improving error handling and script robustness.
- Add `:?` parameter expansion to critical variables (e.g., `STATE_CLUSTER`, `NETWORK_MAGIC`, `DREP_DEPOSIT`, etc.) throughout scripts to fail fast if unset.
- Update file and directory references to consistently use `${VAR:?}` for safety.
- Improves maintainability and prevents silent failures due to unset or empty variables in cluster management scripts.