### PR TITLE
fix(common): set addr to 127.0.0.1 in _gen_tx_generator_config

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -723,7 +723,7 @@ _gen_tx_generator_config() {
       targetNodes: [
         $topology.localRoots[].accessPoints[] |
         {
-          addr: .address,
+          addr: "127.0.0.1",
           port: .port,
           name: ("node" + (.port | tostring))
         }


### PR DESCRIPTION
Previously, the addr field was set to the value of .address from topology.localRoots[].accessPoints[]. This change hardcodes the addr field to "127.0.0.1" when generating the transaction generator config. The address needs to be IP address, not hostname.