### PR TITLE
feat(scripts): add Dijkstra PV12 hard fork support

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -691,7 +691,7 @@ submit_gov_action() {
 
 create_and_submit_hf_action() {
   local hf_action="${1:?}"
-  local era="${2:?}"
+  local cmdgroup="${2:?}"
   local major_version="${3:?}"
   local prev_txid="${4:-}"
   local prev_index="${5:-0}"
@@ -704,7 +704,7 @@ create_and_submit_hf_action() {
     )
   fi
 
-  cardano_cli_log "$era" governance action create-hardfork \
+  cardano_cli_log "$cmdgroup" governance action create-hardfork \
     --testnet \
     --governance-action-deposit "$GOV_ACTION_DEPOSIT" \
     --deposit-return-stake-verification-key-file "${STATE_CLUSTER}/nodes/node-pool1/reward.vkey" \
@@ -1137,6 +1137,41 @@ hf_to_conway_pv11() {
   [ "$cur_protver" = 11 ] || { echo "Unexpected protocol version '$cur_protver' on line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
 }
 
+hf_to_dijkstra() {
+  if [ "$PROTOCOL_VERSION" -lt 12 ]; then
+    echo "Skipping HF to Dijkstra PV12 as PROTOCOL_VERSION is set to $PROTOCOL_VERSION"
+    return
+  fi
+
+  local cur_epoch="${1:?}"
+
+  echo "Submitting hard fork proposal to update to Dijkstra PV12"
+
+  local pv12_hf_base="${STATE_CLUSTER}/governance_data/hardfork_pv12_action"
+  local pv12_hf_action="${pv12_hf_base}_action"
+
+  create_and_submit_hf_action "$pv12_hf_action" "latest" 12 "${PV11_HF_ACTION_TXID:?"Must exist"}"
+
+  PV12_HF_ACTION_TXID="$(cardano_cli_log conway transaction txid \
+    --output-text --tx-body-file "${pv12_hf_action}-tx.txbody")"
+  readonly PV12_HF_ACTION_TXID
+
+  vote_on_action "$PV12_HF_ACTION_TXID" "$pv12_hf_action" "yes" "yes"
+  submit_votes "${pv12_hf_base}_votes" "$pv12_hf_action"
+
+  echo "Waiting for Dijkstra PV12 to start"
+  wait_for_epoch "$((cur_epoch + 2))"
+
+  save_protocol_params "$PPARAMS_FILE"
+  local cur_protver
+  cur_protver="$(jq '.protocolVersion.major' < "$PPARAMS_FILE")"
+  [ "$cur_protver" = 12 ] || { echo "Unexpected protocol version '$cur_protver' on line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+
+  local cur_era
+  cur_era="$(get_era)"
+  [ "$cur_era" = "Dijkstra" ] || { echo "Unexpected era '$cur_era' after HF to Dijkstra PV12, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+}
+
 main() {
   initialize_globals
   setup_state_cluster "${STATE_CLUSTER}/shelley"
@@ -1169,6 +1204,7 @@ main() {
   hf_to_conway "$(get_epoch)"
   hf_to_conway_pv10 "$(get_epoch)"
   hf_to_conway_pv11 "$(get_epoch)"
+  hf_to_dijkstra "$(get_epoch)"
 
   use_genesis_mode
 

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -121,6 +121,25 @@ get_era() {
   cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" | jq -r '.era'
 }
 
+get_node_version() {
+  local _first second major minor patch _
+  read -r _first second _ < <(cardano-node --version 2>/dev/null)
+  [ -n "$second" ] || return 1
+  IFS=. read -r major minor patch <<< "$second"
+  # Strip any non-digit suffix per component (e.g. "11.0.0-pre" -> "11.0.0")
+  printf '%s.%s.%s\n' "${major%%[!0-9]*}" "${minor%%[!0-9]*}" "${patch%%[!0-9]*}"
+}
+
+version_parse() {
+  local v="${1:?"Missing version"}"
+  local major minor patch
+  IFS=. read -r major minor patch <<< "$v"
+  major="${major%%[!0-9]*}"
+  minor="${minor%%[!0-9]*}"
+  patch="${patch%%[!0-9]*}"
+  printf '%d\n' "$((10#${major:-0} * 1000000 + 10#${minor:-0} * 1000 + 10#${patch:-0}))"
+}
+
 get_sec_to_epoch_end() {
   cardano_cli_log latest query tip --testnet-magic "${NETWORK_MAGIC:?}" |
     jq -r "$(get_slot_length) * .slotsToEpochEnd | ceil"
@@ -549,21 +568,35 @@ create_committee_keys_in_genesis() {
 
 edit_genesis_conf() {
   local conf="${1:?"Missing node config file"}"
+  local node_ver node_v11
+  node_ver="$(version_parse "$(get_node_version || echo 0.0.0)")"
+  node_v11="$(version_parse 11.0.0)"
 
   jq \
     --arg byron_hash "${BYRON_GENESIS_HASH:?}" \
     --arg shelley_hash "${SHELLEY_GENESIS_HASH:?}" \
     --arg alonzo_hash "${ALONZO_GENESIS_HASH:?}" \
     --arg conway_hash "${CONWAY_GENESIS_HASH:?}" \
-    --arg dijkstra_hash "${DIJKSTRA_GENESIS_HASH:-}" '
+    --arg dijkstra_hash "${DIJKSTRA_GENESIS_HASH:-}" \
+    --argjson prot_ver "${PROTOCOL_VERSION:?}" \
+    --argjson node_ver "$node_ver" \
+    --argjson node_v11 "$node_v11" \
+    --argjson enable_experimental "$(is_truthy "${ENABLE_EXPERIMENTAL:-}" && echo true || echo false)" '
     .ByronGenesisHash = $byron_hash
     | .ShelleyGenesisHash = $shelley_hash
     | .AlonzoGenesisHash = $alonzo_hash
     | .ConwayGenesisHash = $conway_hash
     | if $dijkstra_hash != "" then
         (.DijkstraGenesisFile = "shelley/genesis.dijkstra.json"
-          | .DijkstraGenesisHash = $dijkstra_hash
-          | .ExperimentalProtocolsEnabled = true
+          | .DijkstraGenesisHash = $dijkstra_hash)
+      else
+        .
+      end
+    | if $enable_experimental
+        or ($prot_ver >= 11 and $node_ver < $node_v11)
+        or ($prot_ver >= 12 and $node_ver >= $node_v11)
+      then
+        (.ExperimentalProtocolsEnabled = true
           | .ExperimentalHardForksEnabled = true)
       else
         .


### PR DESCRIPTION
Add hf_to_dijkstra function to upgrade to Dijkstra PV12. Rename era parameter to cmdgroup in create_and_submit_hf_action to reflect that it accepts a CLI command group. Auto-enable experimental protocols based on cardano-node version and target protocol version.