### PR TITLE
fix(db-sync config): enable off-chain metadata in db-sync configs

### DIFF
--- a/src/cardonnay_scripts/scripts/conway_fast/dbsync-config.yaml
+++ b/src/cardonnay_scripts/scripts/conway_fast/dbsync-config.yaml
@@ -15,6 +15,11 @@ EnableFutureGenesis: True
 # The path to the node config file is relative to this config file.
 NodeConfigFile: config-bft1.json
 
+# Off-chain metadata fetchers default to "disable" since 13.7.0.3 (even under preset "full"); enable explicitly.
+insert_options:
+  offchain_pool_data: "enable"
+  offchain_vote_data: "enable"
+
 # ------------------------------------------------------------------------------
 # Logging configuration follows.
 

--- a/src/cardonnay_scripts/scripts/conway_slow/dbsync-config.yaml
+++ b/src/cardonnay_scripts/scripts/conway_slow/dbsync-config.yaml
@@ -15,6 +15,11 @@ EnableFutureGenesis: True
 # The path to the node config file is relative to this config file.
 NodeConfigFile: config-bft1.json
 
+# Off-chain metadata fetchers default to "disable" since 13.7.0.3 (even under preset "full"); enable explicitly.
+insert_options:
+  offchain_pool_data: "enable"
+  offchain_vote_data: "enable"
+
 # ------------------------------------------------------------------------------
 # Logging configuration follows.
 

--- a/src/cardonnay_scripts/scripts/mainnet_fast/dbsync-config.yaml
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/dbsync-config.yaml
@@ -15,6 +15,11 @@ EnableFutureGenesis: True
 # The path to the node config file is relative to this config file.
 NodeConfigFile: config-bft1.json
 
+# Off-chain metadata fetchers default to "disable" since 13.7.0.3 (even under preset "full"); enable explicitly.
+insert_options:
+  offchain_pool_data: "enable"
+  offchain_vote_data: "enable"
+
 # ------------------------------------------------------------------------------
 # Logging configuration follows.
 


### PR DESCRIPTION
Since cardano-db-sync 13.7.0.3, both `offchain_pool_data` and `offchain_vote_data` default to "disable" - even under `preset: "full"`.

The cardonnay db-sync configs had no `insert_options` block at all, so the off-chain fetcher thread stayed inactive and the `off_chain_pool_*` and `off_chain_vote_*` tables were never populated. This caused that some of cardano-node-tests to time out polling for rows that would never arrive.

Add an explicit `insert_options` block to mainnet_fast, conway_fast, and conway_slow dbsync-config.yaml enabling both fetchers. Other defaults are left untouched (no `preset` key), so this change is scoped strictly to the off-chain failure surface.