### PR TITLE
feat(common.sh): support "lovelace + NoDatum" in get_txins output

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -75,7 +75,7 @@ get_txins() {
                 --testnet-magic "${NETWORK_MAGIC:?}" \
                 --output-text \
                 --address "$txin_addr" |
-                grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$" || echo "")"
+                grep -E "lovelace$|[0-9]$|lovelace \+ TxOutDatumNone$|lovelace \+ NoDatum" || echo "")"
 
     if [ "$TXIN_AMOUNT" -ge "$stop_txin_amount" ]; then
       break


### PR DESCRIPTION
Extend the `get_txins` function to match UTXOs with "lovelace + NoDatum" in addition to existing patterns. This fixes compatibility with the latest `cardano-cli`.