### PR TITLE
feat(dbsync): opt-in --allow-private-offchain-urls via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,25 @@ pip install -U --require-virtualenv cardonnay
 # (Optional) Enable shell completions for Bash
 source completions/cardonnay.bash-completion
 ```
+
+---
+
+## ⚙️ db-sync (optional)
+
+db-sync is started automatically when `DBSYNC_SCHEMA_DIR` points to the
+[`cardano-db-sync`](https://github.com/IntersectMBO/cardano-db-sync) schema directory
+(`cardano-db-sync` must be on your `PATH`). It stays off otherwise.
+
+Set these env vars **before** `cardonnay create`:
+
+| Env var | Effect |
+| --- | --- |
+| `DBSYNC_SCHEMA_DIR` | Path to the db-sync schema dir; enables db-sync. |
+| `SMASH` | Truthy (`1`/`true`/`yes`/`on`) also starts a SMASH server. |
+| `DBSYNC_ALLOW_PRIVATE_OFFCHAIN_URLS` | Truthy lets db-sync fetch off-chain anchor data (pool/governance metadata) served from `localhost`. Needed on a local testnet; off by default. |
+
+```sh
+export DBSYNC_SCHEMA_DIR=/path/to/cardano-db-sync/schema
+export DBSYNC_ALLOW_PRIVATE_OFFCHAIN_URLS=true
+cardonnay create -t conway_fast
+```

--- a/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-dbsync
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
+# Optional env vars:
+#   DBSYNC_ALLOW_PRIVATE_OFFCHAIN_URLS - if truthy, start db-sync with
+#     `--allow-private-offchain-urls` so it can fetch off-chain anchor data
+#     served from localhost (pool / governance metadata on a local testnet).
+#     Off by default.
+
 set -uo pipefail
+
+is_truthy() {
+  local val="${1:-}"
+  case "${val,,}" in
+    1 | true | yes | on | enabled) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 retval=0
 
@@ -29,4 +43,15 @@ export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-postgres}"
 
-exec cardano-db-sync --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml" --socket-path "$CARDANO_NODE_SOCKET_PATH" --state-dir "./$STATE_CLUSTER_NAME/db-sync" --schema-dir "$DBSYNC_SCHEMA_DIR"
+args=(
+  --config "./$STATE_CLUSTER_NAME/dbsync-config.yaml"
+  --socket-path "$CARDANO_NODE_SOCKET_PATH"
+  --state-dir "./$STATE_CLUSTER_NAME/db-sync"
+  --schema-dir "$DBSYNC_SCHEMA_DIR"
+)
+
+if is_truthy "${DBSYNC_ALLOW_PRIVATE_OFFCHAIN_URLS:-}"; then
+  args+=(--allow-private-offchain-urls)
+fi
+
+exec cardano-db-sync "${args[@]}"


### PR DESCRIPTION
db-sync rejects off-chain anchor data served from private/loopback URLs by default, so on a local testnet it cannot validate pool/governance metadata served from localhost. Add an opt-in toggle so db-sync can fetch it.

run-cardano-dbsync now appends --allow-private-offchain-urls when the DBSYNC_ALLOW_PRIVATE_OFFCHAIN_URLS env var is truthy, mirroring how SMASH and DBSYNC_SCHEMA_DIR gate optional db-sync features. Unset/false leaves behaviour unchanged. Truthiness uses a local is_truthy helper matching common.sh (the launcher runs standalone from the state-cluster dir, where common.sh is absent).

Document db-sync enablement and the new flag in the README.