### PR TITLE
refactor(scripts): use args array in run-cardano-submit-api

### DIFF
--- a/src/cardonnay_scripts/scripts/common/run-cardano-submit-api
+++ b/src/cardonnay_scripts/scripts/common/run-cardano-submit-api
@@ -7,15 +7,16 @@ fi
 
 testnet_magic="$(<./state-cluster%%INSTANCE_NUM%%/db-bft1/protocolMagicId)"
 
-echo "Starting cardano-submit-api with PID $$: cardano-submit-api"
-  echo "--config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json"
-  echo "--socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket"
-  echo "--listen-address 127.0.0.1"
-  echo "--port %%SUBMIT_API_PORT%%"
-  echo "--metrics-port %%METRICS_SUBMIT_API_PORT%%"
-  echo --testnet-magic "$testnet_magic"
-echo "..or, once again, in a single line:"
-echo cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"
+args=( \
+  --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json \
+  --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket \
+  --listen-address 127.0.0.1 \
+  --port %%SUBMIT_API_PORT%% \
+  --metrics-port %%METRICS_SUBMIT_API_PORT%% \
+  --testnet-magic "$testnet_magic" \
+  "$@" \
+)
 
-# shellcheck disable=SC2086
-exec cardano-submit-api --config ./state-cluster%%INSTANCE_NUM%%/submit-api-config.json --socket-path ./state-cluster%%INSTANCE_NUM%%/bft1.socket --listen-address 127.0.0.1 --port %%SUBMIT_API_PORT%% --metrics-port %%METRICS_SUBMIT_API_PORT%% --testnet-magic "$testnet_magic"
+echo "Starting cardano-submit-api with PID $$:"
+echo "cardano-submit-api ${args[*]}"
+exec cardano-submit-api "${args[@]}"


### PR DESCRIPTION
Match style of template-cardano-node-pool: build args in an array, forward "$@", and exec with "${args[@]}".