### PR TITLE
Add tx centrifuge load generator support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,7 +17,40 @@
         "type": "github"
       }
     },
+    "CHaP_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_2": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -50,7 +83,41 @@
         "type": "github"
       }
     },
+    "blst_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.15",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
     "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_2": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -84,7 +151,41 @@
         "type": "github"
       }
     },
+    "cabal-34_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
       "flake": false,
       "locked": {
         "lastModified": 1669081697,
@@ -111,6 +212,33 @@
         ],
         "nixpkgs": [
           "cardano-node",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764682512,
+        "narHash": "sha256-yY3yIBmiCKsZ7YN++ttEKZiVMIHjjlAngFWaTGvBBvg=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "9a91636c94317bff98ebf6b913f8c38beef0b374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "type": "github"
+      }
+    },
+    "cardano-automation_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "hackageNix": "hackageNix_3",
+        "haskellNix": [
+          "cardano-node-tx-centrifuge",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-node-tx-centrifuge",
           "nixpkgs"
         ]
       },
@@ -160,7 +288,56 @@
         "type": "github"
       }
     },
+    "cardano-node-tx-centrifuge": {
+      "inputs": {
+        "CHaP": "CHaP_2",
+        "cardano-automation": "cardano-automation_2",
+        "customConfig": "customConfig_2",
+        "empty-flake": "empty-flake_2",
+        "flake-compat": "flake-compat_3",
+        "hackageNix": "hackageNix_4",
+        "haskellNix": "haskellNix_2",
+        "incl": "incl_2",
+        "iohkNix": "iohkNix_2",
+        "nixpkgs": [
+          "cardano-node-tx-centrifuge",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1779244790,
+        "narHash": "sha256-kjTBCb9yFjXm/Kw3JtuSeN3KQx4rPN4Oel1rYLzoYGM=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "2e14d9c2e2dbc37f71bc73a8b2ccbea56ca54c79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "bench/leios-11.0.1",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_2": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -191,7 +368,37 @@
         "type": "github"
       }
     },
+    "customConfig_2": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "empty-flake": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "empty-flake_2": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -240,6 +447,40 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -256,8 +497,23 @@
       }
     },
     "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -290,7 +546,40 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal_2": {
       "flake": false,
       "locked": {
         "lastModified": 1750307553,
@@ -323,6 +612,38 @@
       }
     },
     "hackageNix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774557316,
+        "narHash": "sha256-AErDLAypo/a4gNSKjExpNUM7xdlsTdTf68cWnbr1bOA=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "06fa3e96f4d7ced3496ec984c8016aad5282db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759154585,
+        "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "7e61ac3eb4cc042b37c6511b65984f59fe6d40de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_4": {
       "flake": false,
       "locked": {
         "lastModified": 1774557316,
@@ -394,6 +715,62 @@
         "type": "github"
       }
     },
+    "haskellNix_2": {
+      "inputs": {
+        "HTTP": "HTTP_2",
+        "cabal-32": "cabal-32_2",
+        "cabal-34": "cabal-34_2",
+        "cabal-36": "cabal-36_2",
+        "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_4",
+        "hackage": [
+          "cardano-node-tx-centrifuge",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage_2",
+        "hackage-internal": "hackage-internal_2",
+        "hls": "hls_2",
+        "hls-1.10": "hls-1.10_2",
+        "hls-2.0": "hls-2.0_2",
+        "hls-2.10": "hls-2.10_2",
+        "hls-2.11": "hls-2.11_2",
+        "hls-2.2": "hls-2.2_2",
+        "hls-2.3": "hls-2.3_2",
+        "hls-2.4": "hls-2.4_2",
+        "hls-2.5": "hls-2.5_2",
+        "hls-2.6": "hls-2.6_2",
+        "hls-2.7": "hls-2.7_2",
+        "hls-2.8": "hls-2.8_2",
+        "hls-2.9": "hls-2.9_2",
+        "hpc-coveralls": "hpc-coveralls_2",
+        "iserv-proxy": "iserv-proxy_2",
+        "nixpkgs": [
+          "cardano-node-tx-centrifuge",
+          "nixpkgs"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305_2",
+        "nixpkgs-2311": "nixpkgs-2311_2",
+        "nixpkgs-2405": "nixpkgs-2405_2",
+        "nixpkgs-2411": "nixpkgs-2411_2",
+        "nixpkgs-2505": "nixpkgs-2505_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "old-ghc-nix": "old-ghc-nix_2",
+        "stackage": "stackage_2"
+      },
+      "locked": {
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "hls": {
       "flake": false,
       "locked": {
@@ -427,7 +804,41 @@
         "type": "github"
       }
     },
+    "hls-1.10_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_2": {
       "flake": false,
       "locked": {
         "lastModified": 1687698105,
@@ -461,7 +872,41 @@
         "type": "github"
       }
     },
+    "hls-2.10_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_2": {
       "flake": false,
       "locked": {
         "lastModified": 1747306193,
@@ -495,7 +940,41 @@
         "type": "github"
       }
     },
+    "hls-2.2_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3_2": {
       "flake": false,
       "locked": {
         "lastModified": 1695910642,
@@ -529,7 +1008,41 @@
         "type": "github"
       }
     },
+    "hls-2.4_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5_2": {
       "flake": false,
       "locked": {
         "lastModified": 1701080174,
@@ -563,7 +1076,41 @@
         "type": "github"
       }
     },
+    "hls-2.6_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7_2": {
       "flake": false,
       "locked": {
         "lastModified": 1708965829,
@@ -597,6 +1144,23 @@
         "type": "github"
       }
     },
+    "hls-2.8_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.9": {
       "flake": false,
       "locked": {
@@ -610,6 +1174,39 @@
       "original": {
         "owner": "haskell",
         "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -630,9 +1227,43 @@
         "type": "github"
       }
     },
+    "hpc-coveralls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
+      },
+      "locked": {
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_2": {
+      "inputs": {
+        "nixlib": "nixlib_2"
       },
       "locked": {
         "lastModified": 1693483555,
@@ -672,6 +1303,30 @@
         "type": "github"
       }
     },
+    "iohkNix_2": {
+      "inputs": {
+        "blst": "blst_2",
+        "nixpkgs": [
+          "cardano-node-tx-centrifuge",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_2",
+        "sodium": "sodium_2"
+      },
+      "locked": {
+        "lastModified": 1777941182,
+        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -689,7 +1344,39 @@
         "type": "github"
       }
     },
+    "iserv-proxy_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
     "nixlib": {
+      "locked": {
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_2": {
       "locked": {
         "lastModified": 1667696192,
         "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
@@ -736,7 +1423,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2305_2": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311_2": {
       "locked": {
         "lastModified": 1719957072,
         "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
@@ -768,7 +1487,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2405_2": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411_2": {
       "locked": {
         "lastModified": 1748037224,
         "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
@@ -800,7 +1551,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2505_2": {
+      "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1748856973,
         "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
@@ -833,14 +1616,49 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
-        "flake-utils": "flake-utils_2",
+        "cardano-node-tx-centrifuge": "cardano-node-tx-centrifuge",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs"
       }
     },
     "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_2": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -874,7 +1692,40 @@
         "type": "github"
       }
     },
+    "sodium_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_2": {
       "flake": false,
       "locked": {
         "lastModified": 1755648773,
@@ -920,9 +1771,42 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -6,17 +6,23 @@
     cardano-node = {
       url = "github:IntersectMBO/cardano-node";
     };
+    # tx-centrifuge only, lives on a different cardano-node branch than the
+    # one providing cardano-node / cardano-cli above.
+    cardano-node-tx-centrifuge = {
+      url = "github:IntersectMBO/cardano-node?ref=bench/leios-11.0.1";
+    };
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, cardano-node }:
+  outputs = { self, nixpkgs, flake-utils, cardano-node, cardano-node-tx-centrifuge }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
           nodePkgs = cardano-node.packages.${system};
+          centrifugePkgs = cardano-node-tx-centrifuge.packages.${system};
         in
         {
           devShells = rec {
@@ -33,6 +39,7 @@
                 nodePkgs.cardano-submit-api
                 nodePkgs.bech32
                 nodePkgs.tx-generator
+                centrifugePkgs.tx-centrifuge
                 pkgs.bashInteractive
                 pkgs.python313
               ];

--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -112,6 +112,11 @@ initialize_globals() {
   # shellcheck disable=SC1091
   source "${SCRIPT_DIR}/common.sh"
 
+  if is_truthy "${ENABLE_TX_GENERATOR:-}" && is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
+    echo "ENABLE_TX_GENERATOR and ENABLE_TX_CENTRIFUGE are mutually exclusive, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+
   if [ -e "${SCRIPT_DIR}/shell_env" ]; then
     # shellcheck disable=SC1091
     source "${SCRIPT_DIR}/shell_env"
@@ -547,6 +552,7 @@ main() {
   hf_to_dijkstra "$(get_epoch)"
   use_genesis_mode
   setup_tx_generator "$TX_GENERATOR_MIN_FUNDS"
+  setup_tx_centrifuge
 
   : > "$START_CLUSTER_STATUS"
   echo "Cluster started 🚀"

--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -111,6 +111,11 @@ initialize_globals() {
     exit 1
   fi
 
+  if is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
+    echo "tx-centrifuge is not supported in the slow cluster script, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+
   readonly FUNDS_PER_GENESIS_ADDRESS="$((MAX_SUPPLY / NUM_BFT_NODES))"
   readonly FUNDS_PER_BYRON_ADDRESS="$((FUNDS_PER_GENESIS_ADDRESS * 8 / 10))"
 }

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -571,6 +571,21 @@ startsecs=5
 EoF
   fi
 
+  if is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
+    cp "${SCRIPT_DIR}/run-tx-centrifuge" "${STATE_CLUSTER}"
+
+    cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[program:tx_centrifuge]
+command=./${STATE_CLUSTER_NAME}/run-tx-centrifuge
+stderr_logfile=./${STATE_CLUSTER_NAME}/tx-centrifuge.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/tx-centrifuge.stdout
+autostart=false
+autorestart=false
+startsecs=5
+EoF
+  fi
+
   cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [group:nodes]
@@ -1020,8 +1035,8 @@ _fund_tx_gen() {
 }
 
 _create_tx_gen_config() {
-  if [ $# -lt 4 ]; then
-    echo "Usage: _create_tx_gen_config <topology> <node.socket> <config.json> <genesis.skey>" >&2
+  if [ $# -lt 5 ]; then
+    echo "Usage: _create_tx_gen_config <topology> <node.socket> <config.json> <genesis.skey> <tps>" >&2
     return 1
   fi
 
@@ -1029,6 +1044,7 @@ _create_tx_gen_config() {
   local socket_path="$2"
   local config_file="$3"
   local skey_file="$4"
+  local tps="$5"
 
   if [ ! -f "$topology_file" ]; then
     echo "Error: topology file not found: $topology_file" >&2
@@ -1040,10 +1056,11 @@ _create_tx_gen_config() {
     --arg socket "$socket_path" \
     --arg config "$config_file" \
     --arg skey "$skey_file" \
+    --argjson tps "$tps" \
     '{
       debugMode: false,
       tx_count: 500000,
-      tps: 100,
+      tps: $tps,
       inputs_per_tx: 2,
       outputs_per_tx: 2,
       tx_fee: 212345,
@@ -1118,6 +1135,7 @@ setup_tx_generator() {
   : "${SUPERVISORD_SOCKET_PATH:?SUPERVISORD_SOCKET_PATH is required}"
 
   local fund_amount="${1:?}"
+  local tps="${TX_TPS:-100}"
 
   _fund_tx_gen "$(<"${STATE_CLUSTER}/shelley/genesis-utxo2.addr")" "$fund_amount"
 
@@ -1125,7 +1143,8 @@ setup_tx_generator() {
     "${STATE_CLUSTER}/topology-bft1.json" \
     "./pool1.socket" \
     "./config-pool1.json" \
-    "./shelley/genesis-utxo2.skey" > "${STATE_CLUSTER}/tx-generator-config.json"
+    "./shelley/genesis-utxo2.skey" \
+    "$tps" > "${STATE_CLUSTER}/tx-generator-config.json"
 
   echo "Starting tx-generator"
   supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start tx_generator || \
@@ -1135,4 +1154,190 @@ setup_tx_generator() {
   # The tx generator setup takes time, so we wait for it to start submitting transactions before proceeding
   echo "Waiting for tx generator to start submitting transactions"
   _wait_for_tx_gen_tx
+}
+
+_create_tx_centrifuge_funds() {
+  local skey_file="${1:?}"
+  local value="${2:?}"
+
+  # A single genesis UTxO key fund. tx-centrifuge loads it via `genesis_utxo_keys`
+  # and derives the TxIn from the key with `genesisUTxOPseudoTxIn` (TxIx 0), so the
+  # key must be an untouched genesis initial fund and `value` must match its balance.
+  jq -n \
+    --arg skey "$skey_file" \
+    --argjson value "$value" \
+    '[{signing_key: $skey, value: $value}]'
+}
+
+_create_tx_centrifuge_config() {
+  if [ $# -lt 6 ]; then
+    echo "Usage: _create_tx_centrifuge_config <topology> <config.json> <funds.json> <pparams.json> <magic> <tps>" >&2
+    return 1
+  fi
+
+  local topology_file="$1"
+  local config_file="$2"
+  local funds_file="$3"
+  local pparams_file="$4"
+  local magic="$5"
+  local tps="$6"
+
+  if [ ! -f "$topology_file" ]; then
+    echo "Error: topology file not found: $topology_file" >&2
+    return 1
+  fi
+
+  jq -n \
+    --argjson topology "$(<"$topology_file")" \
+    --arg config "$config_file" \
+    --arg funds "$funds_file" \
+    --arg pparams "$pparams_file" \
+    --argjson magic "$magic" \
+    --argjson tps "$tps" \
+    '{
+      initial_inputs: {
+        type: "genesis_utxo_keys",
+        params: {
+          network_magic: $magic,
+          signing_keys_file: $funds
+        }
+      },
+      builder: {
+        type: "value",
+        params: {
+          inputs_per_tx: 1,
+          outputs_per_tx: 1,
+          fee: 1000000
+        },
+        recycle: {type: "on_build"}
+      },
+      rate_limit: {
+        type: "token_bucket",
+        scope: "shared",
+        params: {tps: $tps}
+      },
+      workloads: {
+        "synthetic-chain": {
+          targets: (
+            # Target a single node only. The workload is one serial 1-in/1-out chain
+            # with `on_build` recycling, so every tx spends the previous tx output. If
+            # the chain were round-robined across several nodes, each dependent tx would
+            # reach a node that has not yet seen its parent, and be rejected as a missing
+            # input. Submitting to one node keeps the chain in one mempool; normal tx
+            # propagation fans it out to the rest of the cluster.
+            [$topology.localRoots[].accessPoints[]][0:1]
+            | map({
+                ("node" + (.port | tostring)): {
+                  addr: "127.0.0.1",
+                  port: .port
+                }
+              })
+            | add
+          )
+        }
+      },
+      nodeConfig: $config,
+      protocolParametersFile: $pparams,
+      # tx-centrifuge reads its own trace config from this file (falls back to a
+      # Debug-severity default when absent). Set a severity threshold on the root
+      # namespace to suppress the very noisy Debug protocol traces while keeping the
+      # Info-level `Builder.NewTx` marker that the startup readiness check greps for.
+      TraceOptions: {
+        "": {
+          severity: "Info",
+          detail: "DNormal",
+          backends: ["Stdout MachineFormat"]
+        }
+      }
+    }'
+}
+
+_wait_for_tx_centrifuge_log() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  local logfile="${STATE_CLUSTER}/tx-centrifuge.stdout"
+  local _
+
+  for _ in {1..10}; do
+    if [ -f "$logfile" ]; then
+      return 0
+    fi
+    sleep 3
+  done
+  echo "Tx centrifuge log file was not created, line $LINENO in ${BASH_SOURCE[0]}" >&2
+  exit 1
+}
+
+_wait_for_tx_centrifuge_tx() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  local logfile="${STATE_CLUSTER}/tx-centrifuge.stdout"
+  local attempts=360
+  local start_time elapsed_time
+  local success=0
+  local a
+
+  start_time="$EPOCHSECONDS"
+  for ((a=1; a<=attempts; a++)); do
+    # The builder emits a `NewTx` trace (severity Info) for every transaction it assembles.
+    if tail -n 100 "$logfile" | grep -q "NewTx"; then
+      success=1
+      break
+    fi
+    sleep 20
+  done
+
+  elapsed_time="$((EPOCHSECONDS - start_time))"
+  if [ "$success" -eq 0 ]; then
+    echo "Tx centrifuge did not start submitting transactions after $elapsed_time seconds, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+  echo "Tx centrifuge started submitting transactions after $elapsed_time seconds"
+}
+
+setup_tx_centrifuge() {
+  if ! is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
+    return 0
+  fi
+
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+  : "${SUPERVISORD_SOCKET_PATH:?SUPERVISORD_SOCKET_PATH is required}"
+  : "${NETWORK_MAGIC:?NETWORK_MAGIC is required}"
+
+  local tps="${TX_TPS:-100}"
+  local addr value
+
+  # Reuse the genesis-utxo2 key. It is a genesis UTxO key, so its genesis initial
+  # fund lives at `genesisUTxOPseudoTxIn` regardless of tx-generator (which funds a
+  # separate UTxO at the same address). tx-generator and tx-centrifuge are mutually
+  # exclusive, so when centrifuge runs this address holds only the genesis UTxO and
+  # its balance matches the value at that TxIn.
+  addr="$(<"${STATE_CLUSTER}/shelley/genesis-utxo2.addr")"
+  value="$(get_address_balance --address "$addr")"
+  if [ "$value" -le 0 ]; then
+    echo "Tx centrifuge genesis UTxO has no funds, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+
+  _create_tx_centrifuge_funds \
+    "./shelley/genesis-utxo2.skey" "$value" > "${STATE_CLUSTER}/funds-tx-centrifuge.json"
+
+  save_protocol_params "${STATE_CLUSTER}/pparams-tx-centrifuge.json"
+
+  _create_tx_centrifuge_config \
+    "${STATE_CLUSTER}/topology-bft1.json" \
+    "./config-pool1.json" \
+    "./funds-tx-centrifuge.json" \
+    "./pparams-tx-centrifuge.json" \
+    "$NETWORK_MAGIC" \
+    "$tps" > "${STATE_CLUSTER}/tx-centrifuge-config.json"
+
+  echo "Starting tx-centrifuge"
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start tx_centrifuge || \
+    { echo "Failed to start tx centrifuge, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+  _wait_for_tx_centrifuge_log
+
+  # The tx centrifuge setup takes time, so we wait for it to start submitting transactions before proceeding
+  echo "Waiting for tx centrifuge to start submitting transactions"
+  _wait_for_tx_centrifuge_tx
 }

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -32,6 +32,25 @@ get_slot_length() {
   echo "$SLOT_LENGTH"
 }
 
+get_active_slot_coeff() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  if [ -z "${ACTIVE_SLOT_COEFF:-}" ]; then
+    ACTIVE_SLOT_COEFF="$(jq '.activeSlotsCoeff' < "${STATE_CLUSTER}/shelley/genesis.json")"
+  fi
+  echo "$ACTIVE_SLOT_COEFF"
+}
+
+get_block_interval_sec() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  # Expected wall-clock seconds between forged blocks: slotLength / activeSlotsCoeff.
+  jq -n \
+    --argjson sl "$(get_slot_length)" \
+    --argjson co "$(get_active_slot_coeff)" \
+    'if $co > 0 then ($sl / $co | ceil) else ($sl | ceil) end'
+}
+
 cardano_cli_log() {
   : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
 
@@ -201,7 +220,8 @@ wait_for_epoch() {
   local sec_to_epoch_end
   local sec_to_sleep
   local curr_epoch
-  local _
+  local poll_interval=5
+  local max_wait attempts i
 
   start_epoch="$(get_epoch)"
 
@@ -215,15 +235,26 @@ wait_for_epoch() {
   sec_to_sleep="$(( sec_to_epoch_end + ((epochs_to_go - 1) * $(get_epoch_sec)) ))"
   sleep "$sec_to_sleep"
 
-  for _ in {1..10}; do
+  # After sleeping to the wall-clock start of the target epoch, we still have to wait
+  # for the first block of that epoch to be forged, because `get_epoch` reads the epoch
+  # of the chain tip. Block production is probabilistic (activeSlotsCoeff), so scale the
+  # grace period to several expected block intervals instead of a fixed window; the loop
+  # returns as soon as the tip reaches the target epoch.
+  max_wait="$(( $(get_block_interval_sec) * 20 ))"
+  if [ "$max_wait" -lt 50 ]; then
+    max_wait=50
+  fi
+  attempts="$(( (max_wait + poll_interval - 1) / poll_interval ))"
+
+  for ((i=1; i<=attempts; i++)); do
     curr_epoch="$(get_epoch)"
     if [ "$curr_epoch" -ge "$target_epoch" ]; then
       return
     fi
-    sleep 5
+    sleep "$poll_interval"
   done
 
-  echo "Unexpected epoch '$curr_epoch' instead of '$target_epoch'" >&2
+  echo "Unexpected epoch '$curr_epoch' instead of '$target_epoch' after waiting ${max_wait}s past the epoch boundary" >&2
   exit 1
 }
 

--- a/src/cardonnay_scripts/scripts/common/run-tx-centrifuge
+++ b/src/cardonnay_scripts/scripts/common/run-tx-centrifuge
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+initialize() {
+  local retval=0
+  local socket_path state_cluster
+
+  if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+    echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+    retval=1
+  fi
+  if ! command -v tx-centrifuge &> /dev/null; then
+    echo "tx-centrifuge is not available in PATH" >&2
+    retval=1
+  fi
+  if [ "$retval" -ne 0 ]; then
+    exit "$retval"
+  fi
+
+  socket_path="$(readlink -m "${CARDANO_NODE_SOCKET_PATH:-}")"
+  state_cluster="${socket_path%/*}"
+  readonly CENTRIFUGE_CONFIG="${state_cluster}/tx-centrifuge-config.json"
+
+  if [ ! -f "$CENTRIFUGE_CONFIG" ]; then
+    echo "Centrifuge config file not found at $CENTRIFUGE_CONFIG" >&2
+    exit 1
+  fi
+
+  cd "$state_cluster"
+}
+
+wait_for_socket() {
+  for _ in {1..5}; do
+    if [ -S "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+      return 0
+    fi
+    echo "Waiting for socket ${CARDANO_NODE_SOCKET_PATH:-} to be available..."
+    sleep 5
+  done
+
+  echo "Socket ${CARDANO_NODE_SOCKET_PATH:-} is not available after waiting" >&2
+  exit 1
+}
+
+run_tx_centrifuge() {
+  local attempt=1
+
+  while true; do
+    wait_for_socket
+
+    echo "Generating transactions..."
+    if tx-centrifuge "$CENTRIFUGE_CONFIG"; then
+      attempt=1
+      sleep 15
+    else
+      if [ $attempt -ge 4 ]; then
+        echo "tx-centrifuge failed after $attempt attempts, exiting." >&2
+        exit 1
+      fi
+      echo "tx-centrifuge failed, retrying in 5 seconds..." >&2
+      attempt=$((attempt + 1))
+      sleep 5
+    fi
+  done
+}
+
+initialize
+run_tx_centrifuge

--- a/src/cardonnay_scripts/scripts/leios_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/leios_fast/testnet.json
@@ -10,6 +10,8 @@
         "DRY_RUN": "if set, will not start the cluster",
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
+        "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }

--- a/src/cardonnay_scripts/scripts/local_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/local_fast/testnet.json
@@ -10,6 +10,8 @@
         "DRY_RUN": "if set, will not start the cluster",
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
+        "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }

--- a/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
@@ -10,6 +10,8 @@
         "DRY_RUN": "if set, will not start the cluster",
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
+        "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }


### PR DESCRIPTION
Adds support for `tx-centrifuge` (a higher-load, UTxO-reusing successor to
`tx-generator`) to the fast testnets, mirroring the existing `tx-generator`
integration. Not supported in the slow script.

### Changes
- **flake**: pin `tx-centrifuge` from cardano-node `bench/leios-11.0.1` as a
  separate input and expose it in the venv dev shell.
- **scripts**: enable via `ENABLE_TX_CENTRIFUGE`. Reuses the `genesis-utxo2`
  key as a `genesis_utxo_keys` fund, targets a single node (so the serial
  `on_build` chain stays in one mempool and propagates out), and pins trace
  severity to `Info`. Mutually exclusive with `tx-generator`.
- **TX_TPS**: single shared variable now sets the rate for both generators
  (tx-generator's rate was previously hardcoded).
- **fix**: scale `wait_for_epoch`'s poll window to block density
  (`slotLength / activeSlotsCoeff`) to stop spurious "Unexpected epoch"
  failures on sparse-block clusters like `leios_fast`.

### Notes
- `protocolParametersFile` is populated (via `save_protocol_params`) for
  forward-compat; the current tool doesn't read it yet.

### Testing
Verified on a running `leios_fast` cluster: mempool fills, ~67% tx acceptance,
`leios.db` grows (EBs produced), tx-centrifuge submits at the configured TPS.