### PR TITLE
feat(scripts): default to protocol version 11

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO in ${BASH_SOURCE[0]}" >&2' ERR
 
-readonly PROTOCOL_VERSION="${PROTOCOL_VERSION:-10}"
+readonly PROTOCOL_VERSION="${PROTOCOL_VERSION:-11}"
 readonly NUM_BFT_NODES=1
 readonly NUM_CC=5
 readonly NUM_DREPS=5

--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -7,7 +7,7 @@
 set -Eeuo pipefail
 trap 'echo "Error at line $LINENO in ${BASH_SOURCE[0]}" >&2' ERR
 
-readonly PROTOCOL_VERSION="${PROTOCOL_VERSION:-10}"
+readonly PROTOCOL_VERSION="${PROTOCOL_VERSION:-11}"
 readonly NUM_BFT_NODES=1
 readonly NUM_CC=5
 readonly NUM_DREPS=5


### PR DESCRIPTION
PV11 support (hf_to_conway_pv11, Dijkstra genesis wiring, experimental flags for pre-11 nodes) is already in place and gated on PROTOCOL_VERSION. Node 11.x treats Conway PV11 as stable. leios_fast keeps its own PV12 default.