### PR TITLE
feat(scripts): integrate tx-firehose as an optional load generator

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,23 @@
         "type": "github"
       }
     },
+    "CHaP_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786144110,
+        "narHash": "sha256-7hIsWllt2gyPIZ8Wvb1BImf9xfQwDkz0B3sXIZpctxg=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "89f08ac683754f1746d5cd1ff4ea60ba13faec29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "index-only",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -51,6 +68,22 @@
       }
     },
     "HTTP_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_3": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -84,6 +117,23 @@
       }
     },
     "blst_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.15",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "blst_3": {
       "flake": false,
       "locked": {
         "lastModified": 1749204514,
@@ -134,6 +184,23 @@
         "type": "github"
       }
     },
+    "cabal-32_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -168,6 +235,23 @@
         "type": "github"
       }
     },
+    "cabal-34_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
       "flake": false,
       "locked": {
@@ -186,6 +270,23 @@
       }
     },
     "cabal-36_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_3": {
       "flake": false,
       "locked": {
         "lastModified": 1669081697,
@@ -239,6 +340,33 @@
         ],
         "nixpkgs": [
           "cardano-node-tx-centrifuge",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764682512,
+        "narHash": "sha256-yY3yIBmiCKsZ7YN++ttEKZiVMIHjjlAngFWaTGvBBvg=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "9a91636c94317bff98ebf6b913f8c38beef0b374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "type": "github"
+      }
+    },
+    "cardano-automation_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "hackageNix": "hackageNix_5",
+        "haskellNix": [
+          "cardano-node-tx-firehose",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
           "nixpkgs"
         ]
       },
@@ -321,6 +449,40 @@
         "type": "github"
       }
     },
+    "cardano-node-tx-firehose": {
+      "inputs": {
+        "CHaP": "CHaP_3",
+        "cardano-automation": "cardano-automation_3",
+        "customConfig": "customConfig_3",
+        "empty-flake": "empty-flake_3",
+        "flake-compat": "flake-compat_5",
+        "hackageNix": "hackageNix_6",
+        "haskellNix": "haskellNix_3",
+        "incl": "incl_3",
+        "iohkNix": "iohkNix_3",
+        "mithril": "mithril",
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "utils": "utils_3"
+      },
+      "locked": {
+        "lastModified": 1786342310,
+        "narHash": "sha256-7RNdXiLC+p+zxn6Iur6jOIrq0IRpfCxjiKAQix+Sc1s=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "c5f7d9121beb67e6d03d0632ae2bd3b76259728e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "leios-prototype",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "cardano-shell": {
       "flake": false,
       "locked": {
@@ -350,6 +512,37 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1776635034,
+        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -383,6 +576,21 @@
         "type": "github"
       }
     },
+    "customConfig_3": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "empty-flake": {
       "locked": {
         "lastModified": 1630400035,
@@ -399,6 +607,21 @@
       }
     },
     "empty-flake_2": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "empty-flake_3": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -481,6 +704,58 @@
         "type": "github"
       }
     },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -512,8 +787,23 @@
       }
     },
     "flake-utils_3": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -563,6 +853,23 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762302430,
+        "narHash": "sha256-thtGuIGrodKEfZPh+Sv22m1BR2zxNQY8RCsGlBWroj4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c5dc9e01d45948892915b5394f23986277fb0ccb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage-internal": {
       "flake": false,
       "locked": {
@@ -580,6 +887,22 @@
       }
     },
     "hackage-internal_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal_3": {
       "flake": false,
       "locked": {
         "lastModified": 1750307553,
@@ -651,6 +974,38 @@
         "owner": "input-output-hk",
         "repo": "hackage.nix",
         "rev": "06fa3e96f4d7ced3496ec984c8016aad5282db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759154585,
+        "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "7e61ac3eb4cc042b37c6511b65984f59fe6d40de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786117442,
+        "narHash": "sha256-hgIx8tjpy6tosXgl5kz38zLGJgnGmLAkix4syRYlEts=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "2fd0dc78a03f432400ad9018f43e2ab31a00ac98",
         "type": "github"
       },
       "original": {
@@ -771,6 +1126,62 @@
         "type": "github"
       }
     },
+    "haskellNix_3": {
+      "inputs": {
+        "HTTP": "HTTP_3",
+        "cabal-32": "cabal-32_3",
+        "cabal-34": "cabal-34_3",
+        "cabal-36": "cabal-36_3",
+        "cardano-shell": "cardano-shell_3",
+        "flake-compat": "flake-compat_6",
+        "hackage": [
+          "cardano-node-tx-firehose",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage_3",
+        "hackage-internal": "hackage-internal_3",
+        "hls": "hls_3",
+        "hls-1.10": "hls-1.10_3",
+        "hls-2.0": "hls-2.0_3",
+        "hls-2.10": "hls-2.10_3",
+        "hls-2.11": "hls-2.11_3",
+        "hls-2.2": "hls-2.2_3",
+        "hls-2.3": "hls-2.3_3",
+        "hls-2.4": "hls-2.4_3",
+        "hls-2.5": "hls-2.5_3",
+        "hls-2.6": "hls-2.6_3",
+        "hls-2.7": "hls-2.7_3",
+        "hls-2.8": "hls-2.8_3",
+        "hls-2.9": "hls-2.9_3",
+        "hpc-coveralls": "hpc-coveralls_3",
+        "iserv-proxy": "iserv-proxy_3",
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
+          "nixpkgs"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305_3",
+        "nixpkgs-2311": "nixpkgs-2311_3",
+        "nixpkgs-2405": "nixpkgs-2405_3",
+        "nixpkgs-2411": "nixpkgs-2411_3",
+        "nixpkgs-2505": "nixpkgs-2505_3",
+        "nixpkgs-unstable": "nixpkgs-unstable_3",
+        "old-ghc-nix": "old-ghc-nix_3",
+        "stackage": "stackage_3"
+      },
+      "locked": {
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "hls": {
       "flake": false,
       "locked": {
@@ -821,6 +1232,23 @@
         "type": "github"
       }
     },
+    "hls-1.10_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.0": {
       "flake": false,
       "locked": {
@@ -839,6 +1267,23 @@
       }
     },
     "hls-2.0_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_3": {
       "flake": false,
       "locked": {
         "lastModified": 1687698105,
@@ -889,6 +1334,23 @@
         "type": "github"
       }
     },
+    "hls-2.10_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.11": {
       "flake": false,
       "locked": {
@@ -907,6 +1369,23 @@
       }
     },
     "hls-2.11_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_3": {
       "flake": false,
       "locked": {
         "lastModified": 1747306193,
@@ -957,6 +1436,23 @@
         "type": "github"
       }
     },
+    "hls-2.2_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.3": {
       "flake": false,
       "locked": {
@@ -975,6 +1471,23 @@
       }
     },
     "hls-2.3_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3_3": {
       "flake": false,
       "locked": {
         "lastModified": 1695910642,
@@ -1025,6 +1538,23 @@
         "type": "github"
       }
     },
+    "hls-2.4_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.5": {
       "flake": false,
       "locked": {
@@ -1043,6 +1573,23 @@
       }
     },
     "hls-2.5_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5_3": {
       "flake": false,
       "locked": {
         "lastModified": 1701080174,
@@ -1093,6 +1640,23 @@
         "type": "github"
       }
     },
+    "hls-2.6_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.7": {
       "flake": false,
       "locked": {
@@ -1111,6 +1675,23 @@
       }
     },
     "hls-2.7_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7_3": {
       "flake": false,
       "locked": {
         "lastModified": 1708965829,
@@ -1161,6 +1742,23 @@
         "type": "github"
       }
     },
+    "hls-2.8_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.9": {
       "flake": false,
       "locked": {
@@ -1195,7 +1793,40 @@
         "type": "github"
       }
     },
+    "hls-2.9_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_3": {
       "flake": false,
       "locked": {
         "lastModified": 1741604408,
@@ -1243,6 +1874,22 @@
         "type": "github"
       }
     },
+    "hpc-coveralls_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
@@ -1264,6 +1911,24 @@
     "incl_2": {
       "inputs": {
         "nixlib": "nixlib_2"
+      },
+      "locked": {
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_3": {
+      "inputs": {
+        "nixlib": "nixlib_3"
       },
       "locked": {
         "lastModified": 1693483555,
@@ -1327,6 +1992,31 @@
         "type": "github"
       }
     },
+    "iohkNix_3": {
+      "inputs": {
+        "blst": "blst_3",
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_3",
+        "sodium": "sodium_3"
+      },
+      "locked": {
+        "lastModified": 1782080462,
+        "narHash": "sha256-jHlPlNk/3PKEx+A++IiWGX3jQtTYzsIM0iTub/VOn2g=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "d7af9d6d6cd3efc91a23772e52fc24a01117f798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "node-11.1",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -1361,6 +2051,46 @@
         "type": "github"
       }
     },
+    "iserv-proxy_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "mithril": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1776926918,
+        "narHash": "sha256-muV2LpheC4OZsU1ipL9j6TmjGufMpGrXzvon+eWahgg=",
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "rev": "2478748ea9771baed8181ef0938c78f79ed60760",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "refs/tags/2617.0",
+        "repo": "mithril",
+        "type": "github"
+      }
+    },
     "nixlib": {
       "locked": {
         "lastModified": 1667696192,
@@ -1391,18 +2121,33 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nixlib_3": {
       "locked": {
-        "lastModified": 1774799055,
-        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1424,6 +2169,22 @@
       }
     },
     "nixpkgs-2305_2": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_3": {
       "locked": {
         "lastModified": 1705033721,
         "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
@@ -1471,6 +2232,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2311_3": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2405": {
       "locked": {
         "lastModified": 1735564410,
@@ -1488,6 +2265,22 @@
       }
     },
     "nixpkgs-2405_2": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405_3": {
       "locked": {
         "lastModified": 1735564410,
         "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
@@ -1535,6 +2328,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411_3": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2505": {
       "locked": {
         "lastModified": 1748852332,
@@ -1567,6 +2376,37 @@
         "type": "github"
       }
     },
+    "nixpkgs-2505_3": {
+      "locked": {
+        "lastModified": 1757716134,
+        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1748856973,
@@ -1595,6 +2435,38 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_3": {
+      "locked": {
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1774799055,
+        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1633,12 +2505,52 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
         "cardano-node-tx-centrifuge": "cardano-node-tx-centrifuge",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs"
+        "cardano-node-tx-firehose": "cardano-node-tx-firehose",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776654897,
+        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "25d75be8139815a53560745fa060909777495105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "secp256k1": {
@@ -1659,6 +2571,23 @@
       }
     },
     "secp256k1_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_3": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -1709,6 +2638,23 @@
         "type": "github"
       }
     },
+    "sodium_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "stackage": {
       "flake": false,
       "locked": {
@@ -1733,6 +2679,22 @@
         "owner": "input-output-hk",
         "repo": "stackage.nix",
         "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762301584,
+        "narHash": "sha256-yLihKEbngbLV1EhuLJSencMCtrDM2sYGsVZkX8xlSK8=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "ce12bd44df0b5488bdbbe8762d79379e2bc76d62",
         "type": "github"
       },
       "original": {
@@ -1786,6 +2748,43 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "cardano-node-tx-firehose",
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
         "systems": "systems"
@@ -1807,6 +2806,24 @@
     "utils_2": {
       "inputs": {
         "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_3": {
+      "inputs": {
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -11,18 +11,23 @@
     cardano-node-tx-centrifuge = {
       url = "github:IntersectMBO/cardano-node?ref=bench/leios-11.0.1";
     };
+    # tx-firehose only, lives on yet another cardano-node branch.
+    cardano-node-tx-firehose = {
+      url = "github:IntersectMBO/cardano-node?ref=leios-prototype";
+    };
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, cardano-node, cardano-node-tx-centrifuge }:
+  outputs = { self, nixpkgs, flake-utils, cardano-node, cardano-node-tx-centrifuge, cardano-node-tx-firehose }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
           nodePkgs = cardano-node.packages.${system};
           centrifugePkgs = cardano-node-tx-centrifuge.packages.${system};
+          firehosePkgs = cardano-node-tx-firehose.packages.${system};
         in
         {
           devShells = rec {
@@ -40,6 +45,7 @@
                 nodePkgs.bech32
                 nodePkgs.tx-generator
                 centrifugePkgs.tx-centrifuge
+                firehosePkgs.tx-firehose
                 pkgs.bashInteractive
                 pkgs.python313
               ];

--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -14,6 +14,7 @@ readonly DREP_DELEGATED=500000000000
 readonly FEE=5000000
 readonly BYRON_INIT_SUPPLY=10020000000
 readonly TX_GENERATOR_MIN_FUNDS=5000000000000000
+readonly TX_FIREHOSE_MIN_FUNDS=5000000000000
 
 readonly INSTANCE_NUM="%%INSTANCE_NUM%%"
 readonly NUM_POOLS=%%NUM_POOLS%%
@@ -112,8 +113,18 @@ initialize_globals() {
   # shellcheck disable=SC1091
   source "${SCRIPT_DIR}/common.sh"
 
-  if is_truthy "${ENABLE_TX_GENERATOR:-}" && is_truthy "${ENABLE_TX_CENTRIFUGE:-}"; then
-    echo "ENABLE_TX_GENERATOR and ENABLE_TX_CENTRIFUGE are mutually exclusive, line $LINENO in ${BASH_SOURCE[0]}" >&2
+  local -a enabled_tx_tools=()
+  local tx_name tx_flag
+  for tx_name in ENABLE_TX_GENERATOR ENABLE_TX_CENTRIFUGE ENABLE_TX_FIREHOSE; do
+    tx_flag="${!tx_name:-}"
+    if is_truthy "$tx_flag"; then
+      enabled_tx_tools+=("$tx_name")
+    fi
+  done
+  if [ "${#enabled_tx_tools[@]}" -gt 1 ]; then
+    local joined
+    printf -v joined '%s, ' "${enabled_tx_tools[@]}"
+    echo "${joined%, } are mutually exclusive, line $LINENO in ${BASH_SOURCE[0]}" >&2
     exit 1
   fi
 
@@ -638,6 +649,7 @@ main() {
   use_genesis_mode
   setup_tx_generator "$TX_GENERATOR_MIN_FUNDS"
   setup_tx_centrifuge
+  setup_tx_firehose "$TX_FIREHOSE_MIN_FUNDS"
 
   : > "$START_CLUSTER_STATUS"
   echo "Cluster started 🚀"

--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -116,6 +116,11 @@ initialize_globals() {
     exit 1
   fi
 
+  if is_truthy "${ENABLE_TX_FIREHOSE:-}"; then
+    echo "tx-firehose is not supported in the slow cluster script, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+
   readonly FUNDS_PER_GENESIS_ADDRESS="$((MAX_SUPPLY / NUM_BFT_NODES))"
   readonly FUNDS_PER_BYRON_ADDRESS="$((FUNDS_PER_GENESIS_ADDRESS * 8 / 10))"
 }

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -622,6 +622,21 @@ startsecs=5
 EoF
   fi
 
+  if is_truthy "${ENABLE_TX_FIREHOSE:-}"; then
+    cp "${SCRIPT_DIR}/run-tx-firehose" "${STATE_CLUSTER}"
+
+    cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
+
+[program:tx_firehose]
+command=./${STATE_CLUSTER_NAME}/run-tx-firehose
+stderr_logfile=./${STATE_CLUSTER_NAME}/tx-firehose.stderr
+stdout_logfile=./${STATE_CLUSTER_NAME}/tx-firehose.stdout
+autostart=false
+autorestart=false
+startsecs=5
+EoF
+  fi
+
   cat >> "${STATE_CLUSTER}/supervisor.conf" <<EoF
 
 [group:nodes]
@@ -1019,7 +1034,7 @@ use_genesis_mode() {
   supervisorctl -s unix:///"${SUPERVISORD_SOCKET_PATH}" restart nodes:
 }
 
-_fund_tx_gen() {
+_fund_address() {
   : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
   : "${FAUCET_ADDR:?FAUCET_ADDR is required}"
   : "${FAUCET_SKEY:?FAUCET_SKEY is required}"
@@ -1028,16 +1043,17 @@ _fund_tx_gen() {
 
   local addr="${1:?}"
   local fund_amount="${2:?}"
+  local label="${3:-fund-address}"
   local fee=500000
   local stop_txin_amount="$((fund_amount + fee))"
-  local tx_base="${STATE_CLUSTER}/shelley/fund-tx-generator"
+  local tx_base="${STATE_CLUSTER}/shelley/${label}"
   local addr_balance
   local -a txins=()
   local txin_amount=0
 
   addr_balance="$(get_address_balance --address "$addr")"
   if [ "$addr_balance" -ge "$fund_amount" ]; then
-    echo "Tx generator address already has enough funds: $addr_balance lovelace"
+    echo "Address '$addr' already has enough funds: $addr_balance lovelace"
     return
   fi
 
@@ -1172,7 +1188,7 @@ setup_tx_generator() {
   local fund_amount="${1:?}"
   local tps="${TX_TPS:-100}"
 
-  _fund_tx_gen "$(<"${STATE_CLUSTER}/shelley/genesis-utxo2.addr")" "$fund_amount"
+  _fund_address "$(<"${STATE_CLUSTER}/shelley/genesis-utxo2.addr")" "$fund_amount" "fund-tx-generator"
 
   _create_tx_gen_config \
     "${STATE_CLUSTER}/topology-bft1.json" \
@@ -1375,4 +1391,116 @@ setup_tx_centrifuge() {
   # The tx centrifuge setup takes time, so we wait for it to start submitting transactions before proceeding
   echo "Waiting for tx centrifuge to start submitting transactions"
   _wait_for_tx_centrifuge_tx
+}
+
+_create_tx_firehose_config() {
+  if [ $# -lt 4 ]; then
+    echo "Usage: _create_tx_firehose_config <node.socket> <signing.skey> <magic> <tps>" >&2
+    return 1
+  fi
+
+  local socket_path="$1"
+  local skey_file="$2"
+  local magic="$3"
+  local tps="$4"
+
+  jq -n \
+    --arg socket "$socket_path" \
+    --arg skey "$skey_file" \
+    --argjson magic "$magic" \
+    --argjson tps "$tps" \
+    '{
+      socket_path: $socket,
+      testnet_magic: $magic,
+      signing_key_file: $skey,
+      tps: $tps,
+      inputs_per_tx: 1,
+      outputs_per_tx: 1,
+      fee: 200000,
+      max_consecutive_errors: 50
+    }'
+}
+
+_wait_for_tx_firehose_log() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  # tx-firehose writes its trace lines to stderr, unlike tx-generator / tx-centrifuge.
+  local logfile="${STATE_CLUSTER}/tx-firehose.stderr"
+  local _
+
+  for _ in {1..10}; do
+    if [ -f "$logfile" ]; then
+      return 0
+    fi
+    sleep 3
+  done
+  echo "Tx firehose log file was not created, line $LINENO in ${BASH_SOURCE[0]}" >&2
+  exit 1
+}
+
+_wait_for_tx_firehose_tx() {
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+
+  local logfile="${STATE_CLUSTER}/tx-firehose.stderr"
+  local attempts=360
+  local start_time elapsed_time
+  local success=0
+  local a
+
+  start_time="$EPOCHSECONDS"
+  for ((a=1; a<=attempts; a++)); do
+    if tail -n 100 "$logfile" | grep -q "TxFirehose.Submit.Success"; then
+      success=1
+      break
+    fi
+    sleep 20
+  done
+
+  elapsed_time="$((EPOCHSECONDS - start_time))"
+  if [ "$success" -eq 0 ]; then
+    echo "Tx firehose did not start submitting transactions after $elapsed_time seconds, line $LINENO in ${BASH_SOURCE[0]}" >&2
+    exit 1
+  fi
+  echo "Tx firehose started submitting transactions after $elapsed_time seconds"
+}
+
+setup_tx_firehose() {
+  if ! is_truthy "${ENABLE_TX_FIREHOSE:-}"; then
+    return 0
+  fi
+
+  : "${STATE_CLUSTER:?STATE_CLUSTER is required}"
+  : "${SUPERVISORD_SOCKET_PATH:?SUPERVISORD_SOCKET_PATH is required}"
+  : "${NETWORK_MAGIC:?NETWORK_MAGIC is required}"
+
+  local fund_amount="${1:?}"
+  local tps="${TX_TPS:-100}"
+
+  # Unlike tx-generator / tx-centrifuge, tx-firehose does not need a genesis UTxO
+  # key -- it discovers its own funds by address query, so any funded key will do.
+  cardano_cli_log conway address key-gen \
+    --signing-key-file "${STATE_CLUSTER}/shelley/tx-firehose.skey" \
+    --verification-key-file "${STATE_CLUSTER}/shelley/tx-firehose.vkey"
+  cardano_cli_log conway address build \
+    --payment-verification-key-file "${STATE_CLUSTER}/shelley/tx-firehose.vkey" \
+    --out-file "${STATE_CLUSTER}/shelley/tx-firehose.addr" \
+    --testnet-magic "$NETWORK_MAGIC"
+
+  _fund_address \
+    "$(<"${STATE_CLUSTER}/shelley/tx-firehose.addr")" "$fund_amount" "fund-tx-firehose"
+
+  _create_tx_firehose_config \
+    "./pool1.socket" \
+    "./shelley/tx-firehose.skey" \
+    "$NETWORK_MAGIC" \
+    "$tps" > "${STATE_CLUSTER}/tx-firehose-config.json"
+
+  echo "Starting tx-firehose"
+  supervisorctl -s "unix:///${SUPERVISORD_SOCKET_PATH}" start tx_firehose || \
+    { echo "Failed to start tx firehose, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
+  _wait_for_tx_firehose_log
+
+  # The tx firehose setup takes time, so we wait for it to start submitting transactions before proceeding
+  echo "Waiting for tx firehose to start submitting transactions"
+  _wait_for_tx_firehose_tx
 }

--- a/src/cardonnay_scripts/scripts/common/run-tx-firehose
+++ b/src/cardonnay_scripts/scripts/common/run-tx-firehose
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+initialize() {
+  local retval=0
+  local socket_path state_cluster
+
+  if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+    echo "CARDANO_NODE_SOCKET_PATH is not set" >&2
+    retval=1
+  fi
+  if ! command -v tx-firehose &> /dev/null; then
+    echo "tx-firehose is not available in PATH" >&2
+    retval=1
+  fi
+  if [ "$retval" -ne 0 ]; then
+    exit "$retval"
+  fi
+
+  socket_path="$(readlink -m "${CARDANO_NODE_SOCKET_PATH:-}")"
+  state_cluster="${socket_path%/*}"
+  readonly FIREHOSE_CONFIG="${state_cluster}/tx-firehose-config.json"
+
+  if [ ! -f "$FIREHOSE_CONFIG" ]; then
+    echo "Firehose config file not found at $FIREHOSE_CONFIG" >&2
+    exit 1
+  fi
+
+  cd "$state_cluster"
+}
+
+wait_for_socket() {
+  for _ in {1..5}; do
+    if [ -S "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+      return 0
+    fi
+    echo "Waiting for socket ${CARDANO_NODE_SOCKET_PATH:-} to be available..."
+    sleep 5
+  done
+
+  echo "Socket ${CARDANO_NODE_SOCKET_PATH:-} is not available after waiting" >&2
+  exit 1
+}
+
+run_tx_firehose() {
+  local attempt=1
+  local socket testnet_magic signing_key tps inputs_per_tx outputs_per_tx fee max_errors
+
+  socket="$(jq -r '.socket_path' "$FIREHOSE_CONFIG")"
+  testnet_magic="$(jq -r '.testnet_magic' "$FIREHOSE_CONFIG")"
+  signing_key="$(jq -r '.signing_key_file' "$FIREHOSE_CONFIG")"
+  tps="$(jq -r '.tps' "$FIREHOSE_CONFIG")"
+  inputs_per_tx="$(jq -r '.inputs_per_tx' "$FIREHOSE_CONFIG")"
+  outputs_per_tx="$(jq -r '.outputs_per_tx' "$FIREHOSE_CONFIG")"
+  fee="$(jq -r '.fee' "$FIREHOSE_CONFIG")"
+  max_errors="$(jq -r '.max_consecutive_errors' "$FIREHOSE_CONFIG")"
+
+  while true; do
+    wait_for_socket
+
+    echo "Generating transactions..."
+    if tx-firehose \
+      --socket-path "$socket" \
+      --testnet-magic "$testnet_magic" \
+      --signing-key-file "$signing_key" \
+      --tps "$tps" \
+      --inputs-per-tx "$inputs_per_tx" \
+      --outputs-per-tx "$outputs_per_tx" \
+      --fee "$fee" \
+      --max-consecutive-errors "$max_errors"; then
+      attempt=1
+      sleep 15
+    else
+      if [ $attempt -ge 4 ]; then
+        echo "tx-firehose failed after $attempt attempts, exiting." >&2
+        exit 1
+      fi
+      echo "tx-firehose failed, retrying in 5 seconds..." >&2
+      attempt=$((attempt + 1))
+      sleep 5
+    fi
+  done
+}
+
+initialize
+run_tx_firehose

--- a/src/cardonnay_scripts/scripts/leios_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/leios_fast/testnet.json
@@ -11,7 +11,8 @@
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
         "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
-        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
+        "ENABLE_TX_FIREHOSE": "if set, will configure and start tx-firehose (single-node, push-based tx load generator over node-to-client)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge / tx-firehose, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }

--- a/src/cardonnay_scripts/scripts/local_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/local_fast/testnet.json
@@ -11,7 +11,8 @@
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
         "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
-        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
+        "ENABLE_TX_FIREHOSE": "if set, will configure and start tx-firehose (single-node, push-based tx load generator over node-to-client)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge / tx-firehose, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }

--- a/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
+++ b/src/cardonnay_scripts/scripts/mainnet_fast/testnet.json
@@ -11,7 +11,8 @@
         "PROTOCOL_VERSION": "if set, will use the specified protocol version (e.g., 11 for latest Conway, etc.)",
         "ENABLE_TX_GENERATOR": "if set, will configure and start tx-generator",
         "ENABLE_TX_CENTRIFUGE": "if set, will configure and start tx-centrifuge (higher-load, UTxO-reusing successor of tx-generator)",
-        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge, default is 100",
+        "ENABLE_TX_FIREHOSE": "if set, will configure and start tx-firehose (single-node, push-based tx load generator over node-to-client)",
+        "TX_TPS": "transactions-per-second rate ceiling for tx-generator / tx-centrifuge / tx-firehose, default is 100",
         "USE_GENESIS_MODE": "if set, will switch to using GenesisMode and peer snapshot file"
     }
 }


### PR DESCRIPTION
Adds tx-firehose alongside tx-generator and tx-centrifuge as a
mutually-exclusive load generator option. Unlike the other two,
tx-firehose needs no genesis UTxO key: it derives its own address and
discovers funds by query, so a freshly generated key funded from the
faucet is enough.
