### PR TITLE
feat(scripts): gate genesis extraConfig downgrade behind env var

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -257,7 +257,9 @@ create_genesis() {
     | .maxLovelaceSupply = $max_supply
     ' "${STATE_CLUSTER}/create_staked/genesis.json" > "${STATE_CLUSTER}/shelley/genesis.json"
 
-  downgrade_genesis_injection "${STATE_CLUSTER}/shelley/genesis.json"
+  if is_truthy "${GENESIS_DOWNGRADE:-}"; then
+    downgrade_genesis_injection "${STATE_CLUSTER}/shelley/genesis.json"
+  fi
   rm -f "${STATE_CLUSTER}/create_staked/genesis.json"
 
   mv "$STATE_CLUSTER"/create_staked/genesis*.json "${STATE_CLUSTER}/shelley/"


### PR DESCRIPTION
Downgrade only runs when GENESIS_DOWNGRADE is set, instead of always attempting it based on node support detection.