### PR TITLE
fix(scripts): stop treating command failure as a pattern match

### DIFF
--- a/src/cardonnay_scripts/scripts/common/common-start-fast
+++ b/src/cardonnay_scripts/scripts/common/common-start-fast
@@ -594,8 +594,10 @@ register_entities() {
 
   if ! is_truthy "${NO_CC:-}"; then
     local cc_size
+    # `grep -c` exits 1 when it counts zero, which under `errexit` would abort here instead of
+    # reaching the diagnostic below.
     cc_size="$(cardano-cli "$command_era" query committee-state --active --testnet-magic "$NETWORK_MAGIC" |
-      grep -c '"status": "Active"')"
+      grep -c '"status": "Active"' || true)"
     [ "$cc_size" -ge "$NUM_CC" ] || \
       { echo "The CC members were not registered, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
   fi

--- a/src/cardonnay_scripts/scripts/common/common-start-slow
+++ b/src/cardonnay_scripts/scripts/common/common-start-slow
@@ -700,8 +700,10 @@ _register_governance_in_conway() {
 
   if ! is_truthy "${NO_CC:-}"; then
     local cc_size
+    # `grep -c` exits 1 when it counts zero, which under `errexit` would abort here instead of
+    # reaching the diagnostic below.
     cc_size="$(cardano-cli conway query committee-state --active --testnet-magic "$NETWORK_MAGIC" |
-      grep -c '"status": "Active"')"
+      grep -c '"status": "Active"' || true)"
     [ "$cc_size" -ge "$NUM_CC" ] || \
       { echo "The CC members were not registered, line $LINENO in ${BASH_SOURCE[0]}" >&2; exit 1; }
   fi

--- a/src/cardonnay_scripts/scripts/common/common.sh
+++ b/src/cardonnay_scripts/scripts/common/common.sh
@@ -53,7 +53,7 @@ get_block_interval_sec() {
 
 has_bls_support() {
   cardano-cli dijkstra node key-gen-BLS --help > /dev/null 2>&1 || return 1
-  cardano-node run --help 2>&1 | grep -q -- '--shelley-bls-key' || return 1
+  grep -q -- '--shelley-bls-key' < <(cardano-node run --help 2>&1) || return 1
   return 0
 }
 
@@ -72,10 +72,13 @@ cardano_cli_log() {
 check_spend_success() {
   : "${NETWORK_MAGIC:?NETWORK_MAGIC is required}"
 
-  local _
+  local _ utxo_out retval
   for _ in {1..10}; do
-    if ! cardano_cli_log latest query utxo "$@" \
-      --testnet-magic "${NETWORK_MAGIC}" --output-text | grep -q lovelace; then
+    # Capture the query separately from the match. Folding both into one condition makes a
+    # failing query indistinguishable from an empty UTxO, reporting the inputs as spent.
+    utxo_out="$(cardano_cli_log latest query utxo "$@" \
+      --testnet-magic "${NETWORK_MAGIC}" --output-text)" && retval=0 || retval="$?"
+    if [ "$retval" -eq 0 ] && ! grep -q lovelace <<< "$utxo_out"; then
       return 0
     fi
     sleep 6
@@ -1231,7 +1234,7 @@ _wait_for_tx_gen_tx() {
 
   start_time="$EPOCHSECONDS"
   for ((a=1; a<=attempts; a++)); do
-    if tail -n 100 "$logfile" | grep -q "SubmissionClientReplyTxIds"; then
+    if grep -q "SubmissionClientReplyTxIds" < <(tail -n 100 "$logfile"); then
       success=1
       break
     fi
@@ -1400,7 +1403,7 @@ _wait_for_tx_centrifuge_tx() {
   start_time="$EPOCHSECONDS"
   for ((a=1; a<=attempts; a++)); do
     # The builder emits a `NewTx` trace (severity Info) for every transaction it assembles.
-    if tail -n 100 "$logfile" | grep -q "NewTx"; then
+    if grep -q "NewTx" < <(tail -n 100 "$logfile"); then
       success=1
       break
     fi
@@ -1518,7 +1521,7 @@ _wait_for_tx_firehose_tx() {
 
   start_time="$EPOCHSECONDS"
   for ((a=1; a<=attempts; a++)); do
-    if tail -n 100 "$logfile" | grep -q "TxFirehose.Submit.Success"; then
+    if grep -q "TxFirehose.Submit.Success" < <(tail -n 100 "$logfile"); then
       success=1
       break
     fi


### PR DESCRIPTION
Three related ways a shell test reported the wrong answer, all by letting a producer's exit status stand in for -- or be mistaken for -- the result of the match.

`grep -q` exits on first match and closes the pipe while the producer may still have a pending write. The producer dies on SIGPIPE with 141, and `pipefail` promotes that to the pipeline's exit status, so the test reads as "no match" even when the pattern is present. It is a race on syscall interleaving, not a size threshold, so it fires intermittently and the odds worsen as the scanned output grows. The three `_wait_for_tx_*_tx` helpers hung a full 7200s timeout each, then failed cluster start, because a healthy tx tool fills the last 100 log lines with the very pattern being matched -- so the match lands on line 1, leaving `tail` with the most left to write. The healthier the tool, the likelier the false negative. Keep the producers out of the pipelines.

`check_spend_success` folded the query and the match into one condition, so a failing `query utxo` produced no output, no `lovelace` match, and the negation returned 0 -- inputs reported as spent, retry loop skipped. Reachable both through the SIGPIPE above and through any ordinary query error. Capture the query and test its status separately.

`grep -c` exits 1 when it counts zero, so the CC registration check aborted at the ERR trap instead of reaching its own error message.